### PR TITLE
Add new rule for discord phishing kit

### DIFF
--- a/indicators/discord-8c89c4f.yml
+++ b/indicators/discord-8c89c4f.yml
@@ -1,0 +1,9 @@
+title: Discord phishing kit 8c89c4f
+description: |
+  Discord phishing kit containing an image URL that only appears in phishing pages
+references:
+  - https://urlscan.io/search/#hash%3A8c89c4f3023d02b04197a30ca20f42ca7eb2634e1432ffff7b9d641a1f71a066
+detection:
+  image:
+    html|contains: 'https://cdn.discordapp.com/attachments/818120722869911602/883999740071657542/nitro.png'
+  condition: image


### PR DESCRIPTION
Add new rule for discord phishing kits reusing the same image

Examples:
- https://urlscan.io/search/#hash%3A8c89c4f3023d02b04197a30ca20f42ca7eb2634e1432ffff7b9d641a1f71a066