### PR TITLE
Add new rule for discord hypesquad phishing kit

### DIFF
--- a/indicators/discord-hypesquad-strolly.yml
+++ b/indicators/discord-hypesquad-strolly.yml
@@ -11,7 +11,7 @@ detection:
   developerSignature:
     html|contains: '<!---By strolly#9548-->'
   nonceCSP:
-    html|contains: 'MjE2LDE0MCwxNzgsMTgwLDY1LDEwOCwxNCwyMjQ='
+    html|contains: 'nonce="MjE2LDE0MCwxNzgsMTgwLDY1LDEwOCwxNCwyMjQ="'
 
   
   condition: developerSignature and nonceCSP

--- a/indicators/discord-hypesquad-strolly.yml
+++ b/indicators/discord-hypesquad-strolly.yml
@@ -1,0 +1,18 @@
+title: Discord Hypesquad phishing kit strolly
+description: |
+  Discord phishing kit containing a comment left behind by the supposed developer of the kit.
+  As well as generic images used across different versions of the kit.
+references:
+  - https://urlscan.io/search/#hash%3Ae6054519e1271faf9134d92dc22e29fbba341275641596a9c32ed37a3c73905f
+  - https://urlscan.io/search/#hash%3A5ee7eb3becab8cd3bf3cf095211f4d35041e9009bb1755771a3fa66aa3a75897
+  - https://urlscan.io/search/#hash%3A0063c8ab81d88071cbe5d1ba5c49a36afd660cc0824e6fac1532c95d5dde1f6f
+  - https://urlscan.io/result/9e6c4a9f-62b4-4b07-81f2-09f10be41cc7
+detection:
+  developerSignature:
+    html|contains: '<!---By strolly#9548-->'
+  humanImage:
+    html|contains: '<img class="human-image" src="assets/human.png">'
+  boyImage:
+    html|contains: '<img class="boy-image" src="assets/boy.png">'
+  
+  condition: developerSignature and humanImage and boyImage

--- a/indicators/discord-hypesquad-strolly.yml
+++ b/indicators/discord-hypesquad-strolly.yml
@@ -1,6 +1,6 @@
 title: Discord Hypesquad phishing kit strolly
 description: |
-  Discord phishing kit containing a comment left behind by the supposed developer of the kit.
+  Discord Hypesquad phishing kit containing a comment left behind by the supposed developer of the kit.
   As well as generic images used across different versions of the kit.
 references:
   - https://urlscan.io/search/#hash%3Ae6054519e1271faf9134d92dc22e29fbba341275641596a9c32ed37a3c73905f

--- a/indicators/discord-hypesquad-strolly.yml
+++ b/indicators/discord-hypesquad-strolly.yml
@@ -10,9 +10,8 @@ references:
 detection:
   developerSignature:
     html|contains: '<!---By strolly#9548-->'
-  humanImage:
-    html|contains: '<img class="human-image" src="assets/human.png">'
-  boyImage:
-    html|contains: '<img class="boy-image" src="assets/boy.png">'
+  nonceCSP:
+    html|contains: 'MjE2LDE0MCwxNzgsMTgwLDY1LDEwOCwxNCwyMjQ='
+
   
-  condition: developerSignature and humanImage and boyImage
+  condition: developerSignature and nonceCSP


### PR DESCRIPTION
Add new rule for discord hypesquad phishing kit developed by `strolly`

Examples:

  - https://urlscan.io/search/#hash%3Ae6054519e1271faf9134d92dc22e29fbba341275641596a9c32ed37a3c73905f
  - https://urlscan.io/search/#hash%3A5ee7eb3becab8cd3bf3cf095211f4d35041e9009bb1755771a3fa66aa3a75897
  - https://urlscan.io/search/#hash%3A0063c8ab81d88071cbe5d1ba5c49a36afd660cc0824e6fac1532c95d5dde1f6f
  - https://urlscan.io/result/9e6c4a9f-62b4-4b07-81f2-09f10be41cc7
