### PR TITLE
Add new rule for discord nitro phishing kit

### DIFF
--- a/indicators/discord-nitro-7a09ee6.yml
+++ b/indicators/discord-nitro-7a09ee6.yml
@@ -1,0 +1,11 @@
+title: Discord Nitro phishing kit 7a09ee6
+description: |
+  Discord Nitro phishing kit containing a reused image asset.
+references:
+  - https://urlscan.io/search/#hash%3A7a09ee6d130ba1b61944d5560df4389bc7073d246a4cde8ea28afe3844725b7f
+  - https://urlscan.io/result/f2a2ec99-edfd-4ab6-86b3-c6f73b8e0bb6/
+detection:
+  nitroImage:
+    html|contains: 'https://cdn.discordapp.com/attachments/933666477016490016/933666487942643722/Discord-Nitro-e1618858537976.png'
+    
+  condition: nitroImage


### PR DESCRIPTION
Add new rule for discord nitro phishing kit reusing the same image across various domains.


Examples:

  - https://urlscan.io/search/#hash%3A7a09ee6d130ba1b61944d5560df4389bc7073d246a4cde8ea28afe3844725b7f
  - https://urlscan.io/result/f2a2ec99-edfd-4ab6-86b3-c6f73b8e0bb6/