### PR TITLE
Update discord-8c89c4f.yml

### DIFF
--- a/indicators/discord-8c89c4f.yml
+++ b/indicators/discord-8c89c4f.yml
@@ -1,9 +1,12 @@
 title: Discord phishing kit 8c89c4f
 description: |
-  Discord phishing kit containing an image URL that only appears in phishing pages
+  Discord phishing kit containing an image (sha256: 8c89c4f3023d02b04197a30ca20f42ca7eb2634e1432ffff7b9d641a1f71a066) 
+  that only appears in phishing pages.
 references:
   - https://urlscan.io/search/#hash%3A8c89c4f3023d02b04197a30ca20f42ca7eb2634e1432ffff7b9d641a1f71a066
 detection:
-  image:
+  imageA:
     html|contains: 'https://cdn.discordapp.com/attachments/818120722869911602/883999740071657542/nitro.png'
-  condition: image
+  imageB:
+    html|contains: 'https://cdn.discordapp.com/attachments/454013565381115916/938124584446754846/nitro.png'
+  condition: imageA or imageB


### PR DESCRIPTION
Adds another IOC URL observed in other samples, both have the same file hash (`8c89c4f3023d02b04197a30ca20f42ca7eb2634e1432ffff7b9d641a1f71a066`)