### PR TITLE
Create luno-exchange-beb8d53.yml

### DIFF
--- a/indicators/luno-exchange-beb8d53.yml
+++ b/indicators/luno-exchange-beb8d53.yml
@@ -1,0 +1,10 @@
+title: Luno crypto exchange phishing kit beb8d53
+description: |
+  Luno crypto exchange phishing kit that has a high entropy string set as the origin-trial value
+references:
+  - https://urlscan.io/search/#hash%3Abeb8d53d9303a2e0a48b25798b83c677de595397e0e82b06ca43b89ed503c845
+detection:
+  originTrialToken:
+    html|contains: 'http-equiv="origin-trial" content="A7dYd5kJpPZNPkzPzk/uHFiBHh1Vy63H7igyI2Dq4m 1d0no9YKaNYQNfAFW3Us09f1k/SiOQW/LKTSjGuLAXg0AAAB eyJvcmlnaW4iOiJodHRwczovL3RlYWRzLnR2OjQ0MyIsImZlYXR1cmUiOiJDb252ZXJzaW9uTWVhc3VyZW1lbnQiLCJleHBpcnkiOjE2NDMxNTUxOTksImlzU3ViZG9tYWluIjp0cnVlLCJpc1RoaXJkUGFydHkiOnRydWV9"'
+  condition: originTrailToken
+


### PR DESCRIPTION
Luno crypto exchange phishing kit that has a high entropy string set as the `origin-trial` value of the meta tag

Example:
- https://urlscan.io/search/#hash%3Abeb8d53d9303a2e0a48b25798b83c677de595397e0e82b06ca43b89ed503c845

Investigation:

Further investigation into what this value actually means, lead me to [this page (Chrome Origin Trials)](http://googlechrome.github.io/OriginTrials/developer-guide.html) which is also in the references below, where it describes this value as the developer's trial token for Chrome Origin Trials.

As per [Sam Dutton](https://developer.chrome.com/authors/samdutton/) of Chrome, Origin trials are a way to test a new or experimental web platform feature, and give feedback to the web standards community on the feature's usability, practicality, and effectiveness, before the feature is made available to all users.

References: 
- http://googlechrome.github.io/OriginTrials/developer-guide.html
- https://developer.chrome.com/origintrials
- https://developer.chrome.com/en/docs/web-platform/origin-trials/