### PR TITLE
Update luno-exchange-beb8d53.yml

### DIFF
--- a/indicators/luno-exchange-beb8d53.yml
+++ b/indicators/luno-exchange-beb8d53.yml
@@ -5,6 +5,6 @@ references:
   - https://urlscan.io/search/#hash%3Abeb8d53d9303a2e0a48b25798b83c677de595397e0e82b06ca43b89ed503c845
 detection:
   originTrialToken:
-    html|contains: 'http-equiv="origin-trial" content="A7dYd5kJpPZNPkzPzk/uHFiBHh1Vy63H7igyI2Dq4m 1d0no9YKaNYQNfAFW3Us09f1k/SiOQW/LKTSjGuLAXg0AAAB eyJvcmlnaW4iOiJodHRwczovL3RlYWRzLnR2OjQ0MyIsImZlYXR1cmUiOiJDb252ZXJzaW9uTWVhc3VyZW1lbnQiLCJleHBpcnkiOjE2NDMxNTUxOTksImlzU3ViZG9tYWluIjp0cnVlLCJpc1RoaXJkUGFydHkiOnRydWV9"'
+    html|contains: 'A7dYd5kJpPZNPkzPzk/uHFiBHh1Vy63H7igyI2Dq4m+1d0no9YKaNYQNfAFW3Us09f1k/SiOQW/LKTSjGuLAXg0AAAB+eyJvcmlnaW4iOiJodHRwczovL3RlYWRzLnR2OjQ0MyIsImZlYXR1cmUiOiJDb252ZXJzaW9uTWVhc3VyZW1lbnQiLCJleHBpcnkiOjE2NDMxNTUxOTksImlzU3ViZG9tYWluIjp0cnVlLCJpc1RoaXJkUGFydHkiOnRydWV9'
   condition: originTrailToken
 

--- a/indicators/luno-exchange-beb8d53.yml
+++ b/indicators/luno-exchange-beb8d53.yml
@@ -6,5 +6,5 @@ references:
 detection:
   originTrialToken:
     html|contains: 'A7dYd5kJpPZNPkzPzk/uHFiBHh1Vy63H7igyI2Dq4m+1d0no9YKaNYQNfAFW3Us09f1k/SiOQW/LKTSjGuLAXg0AAAB+eyJvcmlnaW4iOiJodHRwczovL3RlYWRzLnR2OjQ0MyIsImZlYXR1cmUiOiJDb252ZXJzaW9uTWVhc3VyZW1lbnQiLCJleHBpcnkiOjE2NDMxNTUxOTksImlzU3ViZG9tYWluIjp0cnVlLCJpc1RoaXJkUGFydHkiOnRydWV9'
-  condition: originTrailToken
+  condition: originTrialToken
 


### PR DESCRIPTION
The previous string could not be matched due to the encoding generated via calls to the `escape` JS function. The origin trial token should be a unique enough indicator on its own.