### PR TITLE
Create metamask-604ec65.yml

### DIFF
--- a/indicators/metamask-604ec65.yml
+++ b/indicators/metamask-604ec65.yml
@@ -1,0 +1,12 @@
+title: Metmask Phishing Kit 604ec65
+description: |
+  Metamask Phishing kit that uses WebFlow.
+  Allowing us to flag it due to it having the same WebFlow site key for each phish.
+references:
+  - https://urlscan.io/result/8953ff2a-f891-40cb-9310-7edab6f0876a
+  - https://urlscan.io/result/b4830e43-ef8c-40ac-b4d7-ddf540f2c43b
+detection:
+  webFlowSiteKey:
+    html|contains: 'data-wf-site="604ec65d7935b45ce251b35e"'
+
+  condition: webFlowSiteKey


### PR DESCRIPTION
As per [Revolution](https://discourse.webflow.com/u/Revolution) from the WebFlow forum the `data-wf-site` attribute identifies a specific WebFlow website. The same site key is also used across multiple domains.

Examples:
  - https://urlscan.io/result/8953ff2a-f891-40cb-9310-7edab6f0876a
  - https://urlscan.io/result/b4830e43-ef8c-40ac-b4d7-ddf540f2c43b