### PR TITLE
Create generic-crypto-scam-f634ac3.yml

### DIFF
--- a/indicators/generic-crypto-scam-f634ac3.yml
+++ b/indicators/generic-crypto-scam-f634ac3.yml
@@ -1,0 +1,14 @@
+title: Generic crypto scam f634ac3
+description: |
+  Generic Crypto Scam phishing kit using the same support chat smartSupportKey
+  on different domains.
+references:
+  - https://urlscan.io/result/4f5533cd-7bbd-4ac7-8be9-e566ee7fcd28
+  - https://urlscan.io/result/1bde8ad9-e3d2-420d-a241-da8408dac8f0
+  - https://urlscan.io/result/ef891b01-34f6-4fb2-b8e5-8608f8ab21f7
+  - https://urlscan.io/result/a6ef7324-0948-467e-b062-999737d6b339
+
+detection:
+  smartSupportKey:
+    js|contains: 'f634ac39e6b291ea2c8608cf70bad8bf62185cc3'
+  condition: smartSupportKey


### PR DESCRIPTION
It appears all these crypto scam websites use the same support chat key.

Examples:
  - https://urlscan.io/result/4f5533cd-7bbd-4ac7-8be9-e566ee7fcd28
  - https://urlscan.io/result/1bde8ad9-e3d2-420d-a241-da8408dac8f0
  - https://urlscan.io/result/ef891b01-34f6-4fb2-b8e5-8608f8ab21f7
  - https://urlscan.io/result/a6ef7324-0948-467e-b062-999737d6b339