### PR TITLE
Create coinbase-clone-generic.yml

### DIFF
--- a/indicators/coinbase-132e62b.yml
+++ b/indicators/coinbase-132e62b.yml
@@ -1,0 +1,20 @@
+title: Coinbase phishing kit 132e62b
+description: |
+    Detects a Coinbase phishing kit that uses the same amplitude.js 
+    API key across various domains as well as the same Google Site 
+    Verification keys.
+    
+references:
+  - https://urlscan.io/result/cf711368-757f-4ed2-b45b-47849e93c2c7
+  - https://urlscan.io/result/85d74c2c-b751-4f99-8888-c73518b38919
+
+detection:
+
+  googleSiteVerificationKeyOne:
+    html|contains: 'R7G5THr8xgaHFkTNkr_RUB0HvX2Nf8e4qnWi0X1kmz8'
+
+  googleSiteVerificationKeyTwo:
+    html|contains: '_GaQTkOlc8tLwxDbZfMdxgGPL5wnctrp-vfeavJVsHE'
+
+  amplitudeJSKey:
+    js|contains: '132e62b5953ce8d568137d5887b6b7ab'

--- a/indicators/coinbase-132e62b.yml
+++ b/indicators/coinbase-132e62b.yml
@@ -18,3 +18,5 @@ detection:
 
   amplitudeJSKey:
     js|contains: '132e62b5953ce8d568137d5887b6b7ab'
+    
+  condition: googleSiteVerificationKeyOne and googleSiteVerificationKeyTwo and amplitudeJSKey

--- a/indicators/coinbase-clone-generic.yml
+++ b/indicators/coinbase-clone-generic.yml
@@ -1,8 +1,8 @@
-title: Coinbase phishing kit 132e62b
+title: Coinbase clone generic
 description: |
-    Detects a Coinbase phishing kit that uses the same amplitude.js 
-    API key across various domains as well as the same Google Site 
-    Verification keys.
+    Detects a cloned version of the Coinbase website from the past 
+    that uses the same amplitude.js API key as well as the same 
+    Google Site Verification keys, they used to use.
     
 references:
   - https://urlscan.io/result/cf711368-757f-4ed2-b45b-47849e93c2c7


### PR DESCRIPTION
Seems this Coinbase kit uses the same amplitude.js API key as well as two of the same Google Site Verification keys, across various domains.

Examples:
  - https://urlscan.io/result/cf711368-757f-4ed2-b45b-47849e93c2c7
  - https://urlscan.io/result/85d74c2c-b751-4f99-8888-c73518b38919