### PR TITLE
Create generic-crypto-scam-0694191.yml

### DIFF
--- a/indicators/generic-crypto-scam-0694191.yml
+++ b/indicators/generic-crypto-scam-0694191.yml
@@ -1,0 +1,15 @@
+title: Generic crypto scam 0694191
+description: |
+    Generic Crypto Scam phishing kit that includes a reference to
+    the owner of the website via a HTML link tag
+    
+references:
+  - https://urlscan.io/result/8773a4dc-ccea-49f4-9d35-f907b76d662e
+  - https://urlscan.io/result/0895fbf8-8802-49d3-8f5f-2e40df0ad1fa
+
+detection:
+
+  relLinkBack:
+    html|contains: 'https://www.blogger.com/profile/06941916716624837130'
+    
+  condition: relLinkBack


### PR DESCRIPTION
Detects a generic crypto scam where there is HTML link tag with the `rel` attribute set to `me` and `href` attribute set to a specific blogger profile URL, suggesting that the website belongs to a user on a 3rd party website. 

Reference:
https://microformats.org/wiki/rel-me

Examples:
  - https://urlscan.io/result/8773a4dc-ccea-49f4-9d35-f907b76d662e
  - https://urlscan.io/result/0895fbf8-8802-49d3-8f5f-2e40df0ad1fa