### PR TITLE
Create discord-664a17b.yml

### DIFF
--- a/indicators/discord-664a17b.yml
+++ b/indicators/discord-664a17b.yml
@@ -1,0 +1,23 @@
+title: Discord Phishing Kit 664a17b
+
+description: |
+  Discord phishing kit that uses a external application invite as a lure, 
+  as well as the real DiscordServer discord bot logo to make it seem legitmate.
+  Once the user clicks the button labelled authorize it will open a pop-up window 
+  mimicking the Discord login page pretty poorly. This rule uses the fact that 
+  the same CSS file name is used across all domains that use this kit.
+  
+references:
+  - https://urlscan.io/result/bae8151a-351e-43c5-ba96-46a3f0ea747b
+  - https://urlscan.io/result/b583bcd8-3ca7-412d-a149-45cd3352fb1c
+  - https://urlscan.io/search/#filename:%22general.664a17b86a0ff56191d0.css%22
+  
+detection: 
+
+  generalCSS:
+    requests|contains: 'general.664a17b86a0ff56191d0.css'
+
+  condition: generalCSS
+  
+tags:
+  - target.discord


### PR DESCRIPTION
Detects a discord phishing kit that uses an external application invite as a lure, as well as the real DiscordServer discord bot logo to make it seem legitmate.
Once the user clicks the button labelled authorize it will open a pop-up window mimicking the Discord login page pretty poorly. This rule uses the fact that the same CSS file name is used across all domains that use this kit.

Examples:
  - https://urlscan.io/result/bae8151a-351e-43c5-ba96-46a3f0ea747b
  - https://urlscan.io/result/b583bcd8-3ca7-412d-a149-45cd3352fb1c
  - https://urlscan.io/search/#filename:%22general.664a17b86a0ff56191d0.css%22