### PR TITLE
Adds 5 new IOK rules

### DIFF
--- a/indicators/adobe-5c70696.yml
+++ b/indicators/adobe-5c70696.yml
@@ -1,0 +1,25 @@
+title: Adobe Phishing Kit 5c70696
+description: |
+    Adoba phishing kit which uses the same `template`
+    element `id` attribute as well as having the same
+    value inside the `noscript` tags.
+
+references:
+    - https://urlscan.io/result/bbdc4254-4c3b-46e8-b5a7-b86f8af3c452
+    - https://urlscan.io/result/f6387380-2258-4113-8375-0195ecd1e268
+    - https://urlscan.io/result/dc6f1a1d-ab62-4ac2-9844-1fb15498ce45
+    - https://urlscan.io/result/4b107c8b-c9a2-406f-ad0f-f592d7e26af8
+
+
+detection:
+
+    templateElementID:
+      html|contains: '5c706966-0c66-4623-bdc3-5bd23e958ca3'
+
+    noScriptValue:
+      html|contains: 'f67126f1a0cee6aeda1cbb99c2a1c01f'
+   
+    condition: templateElementID and noScriptValue
+
+tags:
+  - target.adobe

--- a/indicators/base64-url-encoded-body.yml
+++ b/indicators/base64-url-encoded-body.yml
@@ -4,7 +4,8 @@ description: |
   JavaScript functions such as `decodeURIComponent` and `atob` in order
   to evade analysis.
   This helps defeat simple scanners which don't evaluate JavaScript.
-  
+related:
+  - hex-encoded-body
 references:
   - https://urlscan.io/result/f6387380-2258-4113-8375-0195ecd1e268
   

--- a/indicators/base64-url-encoded-body.yml
+++ b/indicators/base64-url-encoded-body.yml
@@ -1,0 +1,19 @@
+title: Base64 & URL-encoded document body
+description: |
+  To evade static analysis, the document body can be wrapped in several
+  JavaScript functions such as `decodeURIComponent` and `atob` in order
+  to evade analysis.
+  This helps defeat simple scanners which don't evaluate JavaScript.
+  
+references:
+  - https://urlscan.io/result/f6387380-2258-4113-8375-0195ecd1e268
+  
+detection:
+
+  documentWriteBase64AndURLDecode:
+    html|contains: "document.write(decodeURIComponent(atob("
+
+  condition: documentWriteBase64AndURLDecode
+
+tags:
+  - anti-analysis

--- a/indicators/facebook-pl-d71c1c.yml
+++ b/indicators/facebook-pl-d71c1c.yml
@@ -1,0 +1,32 @@
+title: Facebook Phishing Kit 7d71c1c
+description: |
+    Detects a Facebook phishing kit targetting 
+    Polish speaking users. Using the same login
+    form structure across all domains as well 
+    as using the same name for the logo file.
+    
+references:
+    - https://urlscan.io/result/4467573b-d13a-4f2c-85df-5dbce3de9eda
+    - https://urlscan.io/result/7d71c1c0-da74-41bf-b4c7-25e9ba421f1e
+    - https://urlscan.io/result/d4890e94-a7e6-4b9a-b4b2-fab8eaa3ccc3
+    - https://urlscan.io/result/dc6ff99f-d94c-4a7a-9337-af606fd6be21
+
+
+detection:
+
+    logo:
+      requests|contains: 'fb4.png'
+
+    loginElement:
+      html|contains|all:
+        - '<div class="loginbox">'
+        - '<input type="text" name="email" placeholder="Numer telefonu komÃ³rkowego lub adres e-mail"> <br>'
+				- '<input type="password" name="pass" placeholder="HasÅ‚o"> <br>'
+				- '<input type="submit" name="get" value="Zaloguj siÄ™"> <br>'
+   
+    condition: logo and loginElement
+
+tags:
+  - target.facebook
+  - target_country.poland
+

--- a/indicators/facebook-pl-d71c1c.yml
+++ b/indicators/facebook-pl-d71c1c.yml
@@ -21,8 +21,8 @@ detection:
       html|contains|all:
         - '<div class="loginbox">'
         - '<input type="text" name="email" placeholder="Numer telefonu komÃ³rkowego lub adres e-mail"> <br>'
-	- '<input type="password" name="pass" placeholder="HasÅ‚o"> <br>'
-	- '<input type="submit" name="get" value="Zaloguj siÄ™"> <br>'
+        - '<input type="password" name="pass" placeholder="HasÅ‚o"> <br>'
+        - '<input type="submit" name="get" value="Zaloguj siÄ™"> <br>'
    
     condition: logo and loginElement
 

--- a/indicators/facebook-pl-d71c1c.yml
+++ b/indicators/facebook-pl-d71c1c.yml
@@ -21,8 +21,8 @@ detection:
       html|contains|all:
         - '<div class="loginbox">'
         - '<input type="text" name="email" placeholder="Numer telefonu komÃ³rkowego lub adres e-mail"> <br>'
-				- '<input type="password" name="pass" placeholder="HasÅ‚o"> <br>'
-				- '<input type="submit" name="get" value="Zaloguj siÄ™"> <br>'
+	- '<input type="password" name="pass" placeholder="HasÅ‚o"> <br>'
+	- '<input type="submit" name="get" value="Zaloguj siÄ™"> <br>'
    
     condition: logo and loginElement
 

--- a/indicators/microsoft-tech-support-0589be7.yml
+++ b/indicators/microsoft-tech-support-0589be7.yml
@@ -1,6 +1,6 @@
-title: Tech support scam kit 
+title: Microsoft Tech Support Kit 0589be7
 description: |
-  Tech support scam kit containing an audio file used across many different domains.
+  A Microsoft Tech support kit containing an audio file used across many different domains.
   As well as a JS function that is used to get the phone number from the URL parameters.
 references:
   - https://urlscan.io/search/#hash%3A0589be7715d2320e559eae6bd26f3528e97450c70293da2e1e8ce45f77f99ab1

--- a/indicators/microsoft-tech-support-jp-d94c3cf.yml
+++ b/indicators/microsoft-tech-support-jp-d94c3cf.yml
@@ -1,0 +1,28 @@
+title: Microsoft Tech Support Kit d94c3cf
+description: |
+    Detects a Microsoft tech support kit targetting 
+    Japanese speaking users. Using the same name for the warning
+    audio file as well as the same class `name` attribute for the 
+    banner elements.
+    
+references:
+    - https://urlscan.io/result/d94c3cf3-223e-4460-b29b-9d50fdb2caad
+    - https://urlscan.io/result/3f9eb89b-f1a8-4bf1-9c2a-604c0efff9ac
+
+
+detection:
+
+    audioFile:
+      requests|contains: 'takashi.mp3'
+
+    bannerElement:
+      html|contains|all: 
+        - 'banner_chat_tel'
+        - 'banner_chat_contact'
+        - 'banner_chat_label'
+   
+    condition: audioFile and bannerElement
+
+tags:
+  - target.microsoft
+  - target_country.japan

--- a/indicators/transferwise-d777126.yml
+++ b/indicators/transferwise-d777126.yml
@@ -17,4 +17,5 @@ detection:
     condition: sentryAPICall
 
 tags:
-  - target.transferwise
+  - target.wise
+

--- a/indicators/transferwise-d777126.yml
+++ b/indicators/transferwise-d777126.yml
@@ -1,0 +1,20 @@
+title: Transferwise Phishing Kit d777126
+description: |
+    Transferwise phishing kit which uses the same sentry.io
+    API key across various domains.
+
+references:
+    - https://urlscan.io/result/6d6dc13f-671c-4c1b-a58c-cc9470bcef2d
+    - https://urlscan.io/result/c6a7e6a2-0b60-46ea-9741-ce53d816d729
+    - https://urlscan.io/result/86f8b7e2-1484-407c-a7b7-93a497014505
+    - https://urlscan.io/result/c2970a14-2b7a-449c-ade9-e4f6fa5c414d
+
+detection:
+
+    sentryAPICall:
+      requests|contains: '?sentry_key=d777126e0316438b8a582a674f5ec311&sentry_version=7'
+   
+    condition: sentryAPICall
+
+tags:
+  - target.transferwise

--- a/indicators/transferwise-d777126.yml
+++ b/indicators/transferwise-d777126.yml
@@ -1,6 +1,7 @@
 title: Transferwise Phishing Kit d777126
 description: |
-    Transferwise phishing kit which uses the same sentry.io
+    Wise phishing kit which uses the same sentry.io
+
     API key across various domains.
 
 references:

--- a/indicators/transferwise-d777126.yml
+++ b/indicators/transferwise-d777126.yml
@@ -1,4 +1,5 @@
-title: Transferwise Phishing Kit d777126
+title: Wise Phishing Kit d777126
+
 description: |
     Wise phishing kit which uses the same sentry.io
 


### PR DESCRIPTION
- Adds 4 new IOK rules for the following imitated brands:
  - TransferWise
  - Facebook 🇵🇱 
  - Microsoft Tech Support 🇯🇵 
  - Adobe
- Additionally adds an IOK rule to detect a new anti-analysis technique using both URL & Base64 encoding
- Also fixes the description and title of the `microsoft-tech-support-0589be7` rule