### PR TITLE
Create dhl-f8e6d46.yml

### DIFF
--- a/indicators/dhl-f8e6d46.yml
+++ b/indicators/dhl-f8e6d46.yml
@@ -1,0 +1,30 @@
+title: DHL Phishing Kit f8e6d46
+description: |
+    Detects a DHL phishing kit that has several indicators that are 
+    exclusive to the kit itself, such as the endpoint where the 
+    credentials are exfiltrated to, and the name of credit card 
+    validation function.
+    
+references:
+  - https://urlscan.io/result/f8e6d46c-0df8-4656-80fb-fe4b4290327b
+  - https://urlscan.io/result/073b610e-dcee-4acb-9a08-20ed20e8cf6a
+  - https://urlscan.io/result/adec9c75-4f47-4563-aee8-d8b9bfebc3f7
+  - https://urlscan.io/result/27b6403b-ea2d-45a6-918f-d08bc5e37534
+  - https://urlscan.io/result/71c1dc24-d7de-4ca1-9a62-113ad2b61264
+  - https://urlscan.io/result/0c66df93-8a8d-41d4-ba4e-61dfda7b50d8
+
+detection:
+
+  formAction:
+    html|contains: 'action="./app/jeandhl'
+
+  backgroundImage:
+    html|contains: 'src="./files/img/delivery-truck.png"'
+
+  cardValidation:
+    html|contains: 'onkeyup="$cc.validate(event)"'
+
+  condition: formAction and backgroundImage and cardValidation
+
+tags:
+  - target.dhl


### PR DESCRIPTION
Detects a DHL phishing kit reusing the same background image, card validation function and credential exfiltration path

Examples:

  - https://urlscan.io/result/f8e6d46c-0df8-4656-80fb-fe4b4290327b
  - https://urlscan.io/result/073b610e-dcee-4acb-9a08-20ed20e8cf6a
  - https://urlscan.io/result/adec9c75-4f47-4563-aee8-d8b9bfebc3f7
  - https://urlscan.io/result/27b6403b-ea2d-45a6-918f-d08bc5e37534
  - https://urlscan.io/result/71c1dc24-d7de-4ca1-9a62-113ad2b61264
  - https://urlscan.io/result/0c66df93-8a8d-41d4-ba4e-61dfda7b50d8