### PR TITLE
Create dpd-1550312.yml

### DIFF
--- a/indicators/dpd-1550312.yml
+++ b/indicators/dpd-1550312.yml
@@ -1,0 +1,29 @@
+title: DPD Phishing Kit 1550321
+description: |
+    Detects a DPD phishing kit using the same fake parcel ID
+    to lure victims in, additionally reuses the same file names
+    and paths for various kit assets.
+    
+references:
+    - https://urlscan.io/result/af837161-2414-49fd-983b-e9dda042f2a5
+    - https://urlscan.io/result/7d7c846c-afa3-4a7e-b1da-4df34e64c71c
+    - https://urlscan.io/result/46c15b10-755a-4c00-8da3-60fe1dbcc126
+    - https://urlscan.io/result/99908906-522d-4450-9d62-04348fb88432
+
+detection:
+
+    fakeParcelID:
+      html|contains: 'Parcel details (15503215866135)'
+
+    siteStyleSheet:
+      requests|contains: 'parse/real.css?'
+
+    logoAsset:
+      requests|contains: 'dpd_group_82x22.png'
+    
+
+    condition: fakeParcelID and siteStyleSheet and logoAsset
+
+tags:
+  - target.dpd
+


### PR DESCRIPTION
Detects a DPD phishing kit using the same fake parcel ID to lure victims in, additionally reuses the same file names and paths for various kit assets.

Examples:
- https://urlscan.io/result/af837161-2414-49fd-983b-e9dda042f2a5
- https://urlscan.io/result/7d7c846c-afa3-4a7e-b1da-4df34e64c71c
- https://urlscan.io/result/46c15b10-755a-4c00-8da3-60fe1dbcc126
- https://urlscan.io/result/99908906-522d-4450-9d62-04348fb88432