### PR TITLE
Create ups-69b689e.yml

### DIFF
--- a/indicators/ups-69b689e.yml
+++ b/indicators/ups-69b689e.yml
@@ -1,0 +1,27 @@
+title: UPS Phishing Kit 69b689e
+description: |
+    Detects a UPS phishing kit a fake parcel ID to lure victims in, 
+    additionally has a high entropy string that does not change
+    assigned as the `data-upstoken` attribute of a HTML element 
+    within the page, possibly left behind when the original UPS 
+    page was cloned. 
+    
+references:
+    - https://urlscan.io/result/24ecab33-02be-4213-9e94-e362f12f9357
+    - https://urlscan.io/result/6fd8922a-873c-4ae4-98e8-b93f3f15a6cc
+    - https://urlscan.io/result/b3259998-efb3-4865-b936-9c81c020f997
+
+detection:
+
+    fakeParcelID:
+      html|contains: 'RAxxxxxxxxxUS'
+
+    upsDataToken:
+      html|contains: '69b689e92856af4eda14fb2bd0418c69158f2943d18691e934ada3ceefb3b914f225910c8bbd05dc221d336eac174899277c8bef3b610c7aa622d42913525889'
+
+
+    condition: fakeParcelID and upsDataToken
+
+tags:
+  - target.ups
+

--- a/indicators/ups-69b689e.yml
+++ b/indicators/ups-69b689e.yml
@@ -1,10 +1,9 @@
 title: UPS Phishing Kit 69b689e
 description: |
-    Detects a UPS phishing kit a fake parcel ID to lure victims in, 
-    additionally has a high entropy string that does not change
-    assigned as the `data-upstoken` attribute of a HTML element 
-    within the page, possibly left behind when the original UPS 
-    page was cloned. 
+    Detects a UPS phishing kit using a fake parcel ID to lure victims in, 
+    additionally has a high entropy string that does not change assigned 
+    as the `data-upstoken` attribute of a HTML element within the page, 
+    possibly left behind when the original UPS page was cloned. 
     
 references:
     - https://urlscan.io/result/24ecab33-02be-4213-9e94-e362f12f9357


### PR DESCRIPTION
 Detects a UPS phishing kit using a fake parcel ID to lure victims in, additionally has a high entropy string that does not change assigned as the `data-upstoken` attribute of a HTML element within the page, possibly left behind when the original UPS page was cloned.

Examples:
  - https://urlscan.io/result/24ecab33-02be-4213-9e94-e362f12f9357
  - https://urlscan.io/result/6fd8922a-873c-4ae4-98e8-b93f3f15a6cc
  - https://urlscan.io/result/b3259998-efb3-4865-b936-9c81c020f997 