### PR TITLE
Create bbva-dd072db.yml

### DIFF
--- a/indicators/bbva-dd072db.yml
+++ b/indicators/bbva-dd072db.yml
@@ -1,6 +1,6 @@
 title: BBVA Phishing Kit dd072db
 description: |
-    Detects a Banco Bilbao Vizcaya Argentaria (BBVA) phishing kit targeting Spanish speaking users.
+    Detects a Banco Bilbao Vizcaya Argentaria (BBVA) phishing kit targeting Argentinian users.
     
 references:
     - https://urlscan.io/result/dec43513-7a12-4cfa-84c1-1a73b9fba8d5
@@ -19,3 +19,4 @@ detection:
 
 tags:
   - target.bbva
+  - target_country.argentina

--- a/indicators/bbva-dd072db.yml
+++ b/indicators/bbva-dd072db.yml
@@ -1,0 +1,21 @@
+title: BBVA Phishing Kit dd072db
+description: |
+    Detects a Banco Bilbao Vizcaya Argentaria (BBVA) phishing kit targeting Spanish speaking users.
+    
+references:
+    - https://urlscan.io/result/dec43513-7a12-4cfa-84c1-1a73b9fba8d5
+    - https://urlscan.io/result/552aa734-2b2c-4f17-8cfe-92bdc38897e8
+    - https://urlscan.io/result/f37238c1-d40e-4c72-b6f6-e3dd4812c39f
+    
+detection:
+
+    cssFile:
+      requests|contains: 'mafalda.css'
+        
+    dataComponentIDAttribute:
+      html|contains: 'dd072dbe-f468-4569-a1a2-8812203f5bf5'
+
+    condition: cssFile and dataComponentIDAttribute
+
+tags:
+  - target.bbva


### PR DESCRIPTION
Detects a Banco Bilbao Vizcaya Argentaria (BBVA) phishing kit targeting Argentinian users.

Examples:
- https://urlscan.io/result/dec43513-7a12-4cfa-84c1-1a73b9fba8d5
- https://urlscan.io/result/552aa734-2b2c-4f17-8cfe-92bdc38897e8
- https://urlscan.io/result/f37238c1-d40e-4c72-b6f6-e3dd4812c39f