### PR TITLE
Create tokenup-crypto-scam.yml

### DIFF
--- a/indicators/tokenup-crypto-scam.yml
+++ b/indicators/tokenup-crypto-scam.yml
@@ -25,7 +25,7 @@ detection:
     blockchainIdentifier:
       html|contains: 'solana'
       
-    condition: (tokenupJsFile and settingsJsFile) or (tokenupJsFile and mintNumber) or (tokenupJsFile and blockchainIdentifier)
+    condition: tokenupJsFile and (settingsJsFile or mintNumber or blockchainIdentifier)
 
 tags:
   - cryptocurrency

--- a/indicators/tokenup-crypto-scam.yml
+++ b/indicators/tokenup-crypto-scam.yml
@@ -1,0 +1,32 @@
+title: Solana cryptocurrency wallet drainer - tokenup
+
+description: |
+    Detects a Solana cryptocurrency wallet drainer that fakes the number
+    of minted NFTs to initiate Fear of Missing Out (FOMO) against the victim.
+
+author: iamdeadlyz
+    
+references:
+    - https://urlscan.io/search/#filename%3A%22tokenup.js%22
+    - https://urlscan.io/result/e72a0ab1-adfb-4e34-871d-6c9903c1e7e0/
+    - https://urlscan.io/result/c1c9e6f2-c66b-4545-acf3-f5ceec21f6b0/
+     
+detection:
+
+    tokenupJsFile:
+      requests|contains: 'tokenup.js'
+
+    settingsJsFile:
+      requests|contains: 'settings.js'
+
+    mintNumber:
+      html|contains: 'tokennumber'
+
+    blockchainIdentifier:
+      html|contains: 'solana'
+      
+    condition: (tokenupJsFile and settingsJsFile) or (tokenupJsFile and mintNumber) or (tokenupJsFile and blockchainIdentifier)
+
+tags:
+  - cryptocurrency
+  - cryptocurrency.solana


### PR DESCRIPTION
Detects a Solana cryptocurrency wallet drainer that fakes the number of minted NFTs to initiate Fear of Missing Out (FOMO) against the victim.

Examples:
- https://urlscan.io/search/#filename%3A%22tokenup.js%22
- https://urlscan.io/result/e72a0ab1-adfb-4e34-871d-6c9903c1e7e0/
- https://urlscan.io/result/c1c9e6f2-c66b-4545-acf3-f5ceec21f6b0/

It's called as "drainer" since it usually takes all of the victim's Solana and sent to the malicious actor's wallet...unless overridden by the settings.