### PR TITLE
Create discord-oauth2-scam-u8eviyps.yml

### DIFF
--- a/indicators/discord-oauth2-scam-u8eviyps.yml
+++ b/indicators/discord-oauth2-scam-u8eviyps.yml
@@ -1,0 +1,29 @@
+title: Discord oAuth2 Scam u8eviyps
+description: |
+    Detects a Discord oAuth2 scam confirmation page, which is often used in combination with social engineering to get the user to authorize for a spam application.
+    This for example enables the attacker to add the victims into further scam/advertised servers using the 'guilds.join' scope.
+    
+references:
+    - https://urlscan.io/result/1314542e-6bdd-496d-a89c-dd20eb60cc99/
+    - https://urlscan.io/result/8b41d331-9749-492c-9616-b133e27880df/
+    - https://urlscan.io/result/0fe1135e-6d7a-4ee9-8da0-c19d971d0ab0/
+
+detection:
+
+    title:
+      html|contains:
+        - <title>Discord Confirmation</title>
+
+    gif:
+      html|contains:
+        - <img id="server_pic" src="https://media.discordapp.net/attachments/851389970840944640/851390759998586910/755244169898885160.gif">
+
+    message:
+      html|contains:
+        - <p>Your Discord account has been successfully verified, you can close this page</p>
+
+    condition: all of them
+
+tags:
+  - scam
+  - target.discord


### PR DESCRIPTION
Adds an indicator that matches a common confirmation page of a Discord oAuth2 scam. Further details are in the description of the rule.
I'm currently tracking down the scammers running this, and an indicator would greatly improve my detection abilities!