### PR TITLE
Update hypixel-b03e14c.yml to work on slightly different urls

### DIFF
--- a/indicators/hypixel-b03e14c.yml
+++ b/indicators/hypixel-b03e14c.yml
@@ -20,8 +20,12 @@ detection:
 
     craftAvatar:
       requests|contains: '7fe0e705f09c468784da02275aefab43?overlay'
-      
-    condition: jsFile and checkoutUpdate and craftAvatar
+    
+    nullMinecraftDataRequests:
+      requests|contains: 'api.minetools.eu/uuid/null'
+      requests|contains: 'minotar.net/avatar/null'
+
+    condition: jsFile and checkoutUpdate and (craftAvatar or nullMinecraftDataRequests)
 
 tags:
   - target.hypixel


### PR DESCRIPTION
Fixes hypixel-b03e14c.yml for e8f038c9-93a5-485f-accd-2b4befaa3a2a
Instead of looking for the same Minecraft head, looks for "null" as the user request for skins. This is probably because of a misconfigured kit, normally the query string has ?name=thephishedperson, so the url parser gets confused, and uses null as the username