### PR TITLE
Create drainer-Iil1il-crypto-scam.yml

### DIFF
--- a/indicators/drainer-Iil1il-crypto-scam.yml
+++ b/indicators/drainer-Iil1il-crypto-scam.yml
@@ -1,0 +1,27 @@
+title: Ethereum cryptocurrency wallet drainer - Iil1ililIl1iIl1ill1Ilii
+
+description: |
+    Detects an Ethereum cryptocurrency wallet drainer that has a 
+    constant variable named Iil1ililIl1iIl1ill1Ilii.
+
+references:
+    - https://urlscan.io/result/394f88b9-1486-444e-b33d-f160a3c99189/
+    - https://urlscan.io/result/3ffdb605-af12-46e0-9f2a-3dac8438b367/
+    - https://urlscan.io/result/86f5a5f4-7286-4f8d-9d35-314f58876322/
+    - https://urlscan.io/result/0ecb3ff3-928a-4fe2-80eb-e052bfc1691d/
+    - https://urlscan.io/result/4d7e7339-3c07-49c8-acff-9999d3f0e8a8/
+    - https://urlscan.io/result/85a90895-e233-4399-91cd-dd4bcea52b8f/
+
+detection:
+
+    drainerVariableIdentifierHTML:
+      html|contains: 'Iil1ililIl1iIl1ill1Ilii'
+
+    drainerVariableIdentifierJS:
+      js|contains: 'Iil1ililIl1iIl1ill1Ilii'
+
+    condition: drainerVariableIdentifierHTML or drainerVariableIdentifierJS
+
+tags:
+  - cryptocurrency
+  - cryptocurrency.ethereum


### PR DESCRIPTION
Detects an Ethereum cryptocurrency wallet drainer that has a constant variable named Iil1ililIl1iIl1ill1Ilii.

Examples:
- https://urlscan.io/result/394f88b9-1486-444e-b33d-f160a3c99189/
- https://urlscan.io/result/3ffdb605-af12-46e0-9f2a-3dac8438b367/
- https://urlscan.io/result/86f5a5f4-7286-4f8d-9d35-314f58876322/
- https://urlscan.io/result/0ecb3ff3-928a-4fe2-80eb-e052bfc1691d/
- https://urlscan.io/result/4d7e7339-3c07-49c8-acff-9999d3f0e8a8/
- https://urlscan.io/result/85a90895-e233-4399-91cd-dd4bcea52b8f/