### PR TITLE
Add ics.yml

### DIFF
--- a/indicators/ics.yml
+++ b/indicators/ics.yml
@@ -1,0 +1,20 @@
+title: International Card Services phishing kit
+description: |
+    Detects a phishing kit for a creditcard processor which uses the same hidden value across various domains.
+    
+references:
+- https://urlscan.io/result/5cea2922-3642-4dc0-b41b-89e914a70f94
+- https://urlscan.io/result/44382989-2570-4b17-9fe8-962b6e341ddb
+- https://urlscan.io/result/7d2a26cd-8307-46be-9991-e691c962c2ea
+- https://urlscan.io/result/52ccdfe2-5af4-4b5b-a70c-73e2cd7b56e6
+
+detection:
+
+    did_proxy:
+      html|contains: <input id="did_proxy" name="did_proxy" type="hidden" value="1:zEUeQFVqXRrb1FthfkZ64J1LHpob1ksgZd7jHNpUxXxlq0gz2-i7oZP9U70asvhwgYSKXzVQArfJATAYu8N_bw">
+
+    condition: did_proxy
+
+tags:
+  - target.international-card-services
+  - target_country.netherlands


### PR DESCRIPTION
Detects a phishing kits targeting a credit card processor in the Netherlands which has a constant variable in a hidden element

Examples:
- https://urlscan.io/result/5cea2922-3642-4dc0-b41b-89e914a70f94
- https://urlscan.io/result/44382989-2570-4b17-9fe8-962b6e341ddb
- https://urlscan.io/result/7d2a26cd-8307-46be-9991-e691c962c2ea
- https://urlscan.io/result/52ccdfe2-5af4-4b5b-a70c-73e2cd7b56e6
- https://urlscan.io/result/4a2b4f5b-c5d1-4fb6-b3d1-41231c886054