### PR TITLE
Create submit-form-com.yml

### DIFF
--- a/indicators/submit-form-com.yml
+++ b/indicators/submit-form-com.yml
@@ -1,0 +1,19 @@
+title: Exfiltration using submit-form
+
+description: |
+  submit-form is a service that takes HTML form submissions and sends the results to an email address, online dashboard, or webhook, depending on the threat actor.
+
+  It can be used by threat actors building "serverless" phishing pages i.e. where they don't have a backend server that can send emails or store logs.
+
+references:
+    - https://urlscan.io/result/92fa719f-0df2-4192-a96d-fea2e50c31fa/
+
+detection:
+
+  formAction:
+    html|contains: "action=\"https://submit-form.com/"
+    
+  condition: formAction
+
+tags:
+  - exfiltration


### PR DESCRIPTION
submit-form is a service that takes HTML form submissions and sends the results to an email address, online dashboard, or webhook, depending on the threat actor.

It can be used by threat actors building "serverless" phishing pages i.e. where they don't have a backend server that can send emails or store logs.

Example:
- https://urlscan.io/result/92fa719f-0df2-4192-a96d-fea2e50c31fa/