### PR TITLE
Make IOK fail on failed rule parsing

### DIFF
--- a/iok.go
+++ b/iok.go
@@ -90,6 +90,9 @@ func init() {
 		contents, _ := indicators.ReadFile(path)
 
 		rule, err := ParseRule(path, contents)
+		if err != nil {
+			return err
+		}
 		Rules[rule.ID] = rule
 		RawRules[rule.ID] = contents
 


### PR DESCRIPTION
Before it would lead to a mysterious segfault, which isn't very helpful. This patch returns the error, which normally has a less cryptic message about what went wrong