### PR TITLE
Create indicator: UOL Mail 6xm0cU

### DIFF
--- a/indicators/uol-mail-6xm0cu.yml
+++ b/indicators/uol-mail-6xm0cu.yml
@@ -1,4 +1,4 @@
-title: UOL Mail 6xm0cU
+title: UOL Mail Phishing Kit 6xm0cU
 description: |
     Detects a phishing kit targeting UOL Mail.
     UOL is a Brazilian content, digital services and technology company.

--- a/indicators/uol-mail-6xm0cu.yml
+++ b/indicators/uol-mail-6xm0cu.yml
@@ -1,0 +1,28 @@
+title: UOL Mail 6xm0cU
+description: |
+    Detects a phishing kit targeting UOL Mail.
+    UOL is a Brazilian content, digital services and technology company.
+
+
+references:
+    - https://urlscan.io/result/e0b0c082-df0f-4192-a438-6205b836909c/
+    - https://urlscan.io/result/69068df9-1fc4-4291-b455-5cb530a310b4/
+
+detection:
+
+    css:
+      html|contains:
+        - link href="dsnucnsduq332/main.943c4b5a.chunk.css" rel="stylesheet"
+    img1:
+      html|contains:
+        - img src="dsnucnsduq332/logo_bagui12312mail2.png"
+    img2:
+      html|contains:
+        - img src="dsnucnsduq332/bagui12312-minimalist-logo.svg"
+
+    condition: css and img1 and img2
+
+tags:
+  - kit
+  - target.uol
+  - target_country.brazil


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Creator**

✅ Indicator matches **2**/**2** referenced Urlscan results.

ID: `uol-mail-6xm0cu`
Title: `UOL Mail Phishing Kit 6xm0cU`
Description:
```
Detects a phishing kit targeting UOL Mail.
UOL is a Brazilian content, digital services and technology company.
```
References:
https://urlscan.io/result/e0b0c082-df0f-4192-a438-6205b836909c/
https://urlscan.io/result/69068df9-1fc4-4291-b455-5cb530a310b4/
Tags: `kit`, `target.uol`, `target_country.brazil` (🇧🇷)
Screenshot:
<img src="https://urlscan.io/screenshots/e0b0c082-df0f-4192-a438-6205b836909c.png" width="800" height="600" />