### PR TITLE
Create indicator: Interfisa Banco rw6N5v

### DIFF
--- a/indicators/interfisa-banco-rw6n5v.yml
+++ b/indicators/interfisa-banco-rw6n5v.yml
@@ -1,0 +1,36 @@
+title: Interfisa Banco rw6N5v
+description: |
+    Detects a phishing kit targeting Interfisa Banco. This was found as a result of a user deploying this phishing kit on Replit.
+
+
+references:
+    - https://urlscan.io/result/cd660a10-74c5-42f2-8b45-53a49202ea34/
+
+detection:
+
+    div1:
+      html|contains:
+        - 'div title="Elija una opción" class="textbox-wrap"'
+    div2:
+      html|contains:
+        - 'div title="Ingrese su nro. de documento" class="textbox-wrap"'
+    div3:
+      html|contains:
+        - 'div title="Ingrese su contraseña" class="textbox-wrap"'
+    title:
+      html|contains:
+        - <title>Interfisa Home</title>
+    a:
+      html|contains:
+        - 'a href="https://digital.interfisa.com.py/#!/cuenta-digital/inicio?canal=8" class="a-login" style="font-size: 1em;"'
+    img:
+      html|contains:
+        - 'img src="main/imagestest.png" alt="" style="width: 70%;"'
+
+    condition: div1 and div2 and div3 and title and a and img
+
+tags:
+  - kit
+  - target.interfisa_banco
+  - target.interfisa
+  - target_country.paraguay

--- a/indicators/interfisa-banco-rw6n5v.yml
+++ b/indicators/interfisa-banco-rw6n5v.yml
@@ -8,26 +8,16 @@ references:
 
 detection:
 
-    div1:
-      html|contains:
-        - 'div title="Elija una opción" class="textbox-wrap"'
-    div2:
-      html|contains:
-        - 'div title="Ingrese su nro. de documento" class="textbox-wrap"'
-    div3:
-      html|contains:
-        - 'div title="Ingrese su contraseña" class="textbox-wrap"'
-    title:
-      html|contains:
-        - <title>Interfisa Home</title>
-    a:
-      html|contains:
-        - 'a href="https://digital.interfisa.com.py/#!/cuenta-digital/inicio?canal=8" class="a-login" style="font-size: 1em;"'
-    img:
-      html|contains:
-        - 'img src="main/imagestest.png" alt="" style="width: 70%;"'
+    imageFilename:
+        html|contains: 'img-index.jpg'
+  
+    iconClass:
+        html|contains: 'fa fa-university'
 
-    condition: div1 and div2 and div3 and title and a and img
+    googleCaptchaVersion:
+        html|contains: 'VZKEDW9wslPbEc9RmzMqaOAP'
+
+    condition: imageFilename and iconClass and googleCaptchaVersion
 
 tags:
   - kit

--- a/indicators/interfisa-banco-rw6n5v.yml
+++ b/indicators/interfisa-banco-rw6n5v.yml
@@ -1,4 +1,4 @@
-title: Interfisa Banco rw6N5v
+title: Interfisa Banco Phishing Kit rw6N5v
 description: |
     Detects a phishing kit targeting Interfisa Banco. This was found as a result of a user deploying this phishing kit on Replit.
 


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Creator**

✅ Indicator matches **1**/**1** referenced Urlscan results.

ID: `interfisa-banco-rw6n5v`
Title: `Interfisa Banco Phishing Kit rw6N5v`
Description:
```
Detects a phishing kit targeting Interfisa Banco. This was found as a result of a user deploying this phishing kit on Replit.
```
References:
https://urlscan.io/result/cd660a10-74c5-42f2-8b45-53a49202ea34/
Tags: `kit`, `target.interfisa_banco`, `target.interfisa`, `target_country.paraguay` (🇵🇾)
Screenshot:
<img src="https://urlscan.io/screenshots/cd660a10-74c5-42f2-8b45-53a49202ea34.png" width="800" height="600" />