### PR TITLE
Create indicator: Bancolombia GM866x

### DIFF
--- a/indicators/bancolombia-gm866x.yml
+++ b/indicators/bancolombia-gm866x.yml
@@ -1,4 +1,4 @@
-title: Bancolombia GM866x
+title: Bancolombia Phishing Kit GM866x
 description: |
     Detects a phishing kit targeting Bancolombia with a simple centered login form.
     This was detected as a result of this kit being deployed on Replit.

--- a/indicators/bancolombia-gm866x.yml
+++ b/indicators/bancolombia-gm866x.yml
@@ -1,4 +1,4 @@
-title: bancolombia GM866x
+title: Bancolombia GM866x
 description: |
     Detects a phishing kit targeting Bancolombia with a simple centered login form.
     This was detected as a result of this kit being deployed on Replit.

--- a/indicators/bancolombia-gm866x.yml
+++ b/indicators/bancolombia-gm866x.yml
@@ -1,0 +1,46 @@
+title: bancolombia GM866x
+description: |
+    Detects a phishing kit targeting Bancolombia with a simple centered login form.
+    This was detected as a result of this kit being deployed on Replit.
+
+
+references:
+    - https://urlscan.io/result/056508ef-a7c6-40b1-8778-5b180662a59d/
+    - https://urlscan.io/result/a878d133-716c-495f-89a3-daa8c1b3f8b1/
+    - https://urlscan.io/result/4efb97ab-2eb7-4eb6-bb3e-070cf2492f5c/
+    - https://urlscan.io/result/af65c797-d244-438b-91db-8450d0c42381/
+    - https://urlscan.io/result/32b05873-e5ac-4099-bda6-082b80d7e377/
+    - https://urlscan.io/result/b7c96948-36dc-45de-91d1-b96621d4d49f/
+    - https://urlscan.io/result/abbcb8aa-9a07-4394-995f-f5a3622da43f/
+    - https://urlscan.io/result/dd5c04e9-6d7a-4ec5-83f6-bae7ca553944/
+    - https://urlscan.io/result/e6082228-fdd9-4b71-81bb-57a0796b79a6/
+    - https://urlscan.io/result/abcea60a-e6e1-4fdb-8a34-cec1be9fdbb1/
+
+detection:
+
+    title:
+      html|contains:
+        - <title>home</title>
+
+    backgroundImage:
+      html|contains:
+        - "background-image: url('archivero/bg-01.jpg')"
+
+    loginWrapper:
+      html|contains:
+        - div class="wrap-login100 p-l-110 p-r-110 p-t-62 p-b-33"
+
+    css:
+      html|contains|all:
+        - link rel="stylesheet" type="text/css" href="archivero/font-awesome.min.css"
+        - link rel="stylesheet" type="text/css" href="archivero/icon-font.min.css"
+        - link rel="stylesheet" type="text/css" href="archivero/util.css"
+        - link rel="stylesheet" type="text/css" href="archivero/main.css"
+
+
+    condition: title and backgroundImage and loginWrapper and css
+
+tags:
+  - kit
+  - target.bancolombia
+  - target_country.colombia


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Creator**

✅ Indicator matches **10**/**10** referenced Urlscan results.

ID: `bancolombia-gm866x`
Title: `Bancolombia Phishing Kit GM866x`
Description:
```
Detects a phishing kit targeting Bancolombia with a simple centered login form.
This was detected as a result of this kit being deployed on Replit.
```
References:
https://urlscan.io/result/056508ef-a7c6-40b1-8778-5b180662a59d/
https://urlscan.io/result/a878d133-716c-495f-89a3-daa8c1b3f8b1/
https://urlscan.io/result/4efb97ab-2eb7-4eb6-bb3e-070cf2492f5c/
https://urlscan.io/result/af65c797-d244-438b-91db-8450d0c42381/
https://urlscan.io/result/32b05873-e5ac-4099-bda6-082b80d7e377/
https://urlscan.io/result/b7c96948-36dc-45de-91d1-b96621d4d49f/
https://urlscan.io/result/abbcb8aa-9a07-4394-995f-f5a3622da43f/
https://urlscan.io/result/dd5c04e9-6d7a-4ec5-83f6-bae7ca553944/
https://urlscan.io/result/e6082228-fdd9-4b71-81bb-57a0796b79a6/
https://urlscan.io/result/abcea60a-e6e1-4fdb-8a34-cec1be9fdbb1/
Tags: `kit`, `target.bancolombia`, `target_country.colombia` (🇨🇴)
Screenshot:
<img src="https://urlscan.io/screenshots/056508ef-a7c6-40b1-8778-5b180662a59d.png" width="800" height="600" />