### PR TITLE
Create indicator: Banco Pichincha niUG0Z

### DIFF
--- a/indicators/banco-pichincha-niug0z.yml
+++ b/indicators/banco-pichincha-niug0z.yml
@@ -1,0 +1,39 @@
+title: Banco Pichincha niUG0Z
+description: |
+    Detects a phishing kit targeting Banco Pichincha. Banco Pichincha is the largest private-sector bank in Ecuador.
+    This was detected as a result of this kit being deployed on Replit.
+
+
+references:
+    - https://urlscan.io/result/0c5c87f6-0de1-4b69-bbcf-ebfec08241e6/
+    - https://urlscan.io/result/db339903-08f1-4be6-9c55-47227d18f42e/
+    - https://urlscan.io/result/473f8be9-a375-48d1-a6c5-cd07a9021d81/
+
+detection:
+
+    title:
+      html|contains:
+        - <title>Login</title>
+
+    css:
+      html|contains|all:
+        - link rel="stylesheet" href="assets/css/explorer-message-05236.css"
+        - link rel="stylesheet" href="assets/css/styles.05.css"
+        - link rel="stylesheet" href="assets/css/styles.45fc6f0f.css"
+
+    guid:
+      html|contains:
+        - div id="2a94e1b1-6526-42dc-9c3a-e7a1eda7e463"
+
+    copyright:
+      html|contains:
+        - © 2022 Banco Pichincha. Todos los derechos reservados
+
+
+    condition: title and css and guid and copyright
+
+tags:
+  - kit
+  - target.banco_pichincha
+  - target.pichincha
+  - target_country.ecuador

--- a/indicators/banco-pichincha-niug0z.yml
+++ b/indicators/banco-pichincha-niug0z.yml
@@ -1,4 +1,4 @@
-title: Banco Pichincha niUG0Z
+title: Banco Pichincha Phishing Kit niUG0Z
 description: |
     Detects a phishing kit targeting Banco Pichincha. Banco Pichincha is the largest private-sector bank in Ecuador.
     This was detected as a result of this kit being deployed on Replit.

--- a/indicators/banco-pichincha-niug0z.yml
+++ b/indicators/banco-pichincha-niug0z.yml
@@ -21,16 +21,12 @@ detection:
         - link rel="stylesheet" href="assets/css/styles.05.css"
         - link rel="stylesheet" href="assets/css/styles.45fc6f0f.css"
 
-    guid:
-      html|contains:
-        - div id="2a94e1b1-6526-42dc-9c3a-e7a1eda7e463"
-
     copyright:
       html|contains:
-        - © 2022 Banco Pichincha. Todos los derechos reservados
+        - "© 2022 Banco Pichincha. Todos los derechos reservados"
 
 
-    condition: title and css and guid and copyright
+    condition: title and css and copyright
 
 tags:
   - kit


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Creator**

✅ Indicator matches **3**/**3** referenced Urlscan results.

ID: `banco-pichincha-niug0z`
Title: `Banco Pichincha Phishing Kit niUG0Z`
Description:
```
Detects a phishing kit targeting Banco Pichincha. Banco Pichincha is the largest private-sector bank in Ecuador.
This was detected as a result of this kit being deployed on Replit.
```
References:
https://urlscan.io/result/0c5c87f6-0de1-4b69-bbcf-ebfec08241e6/
https://urlscan.io/result/db339903-08f1-4be6-9c55-47227d18f42e/
https://urlscan.io/result/473f8be9-a375-48d1-a6c5-cd07a9021d81/
Tags: `kit`, `target.banco_pichincha`, `target.pichincha`, `target_country.ecuador` (🇪🇨)
Screenshot:
<img src="https://urlscan.io/screenshots/0c5c87f6-0de1-4b69-bbcf-ebfec08241e6.png" width="800" height="600" />