### PR TITLE
Create indicator: Credicorp Bank Phishing Kit tGeBlg

### DIFF
--- a/indicators/credicorp-bank-tgeblg.yml
+++ b/indicators/credicorp-bank-tgeblg.yml
@@ -12,10 +12,9 @@ references:
 
 detection:
 
-    headerCapitalization:
+    csrf:
       html|contains|all:
-        - meta http-equiv="CACHE-CONTROL" content="NO-CACHE"
-        - meta http-equiv="PRAGMA" content="NO-CACHE"
+        - name="SESSION_CSRF_TOKEN" tabindex="0" lang="es" id="loginToken" value="0f234c429f530238b63c6793ca994d0c85c6f37b"
 
     dojoJS:
       html|contains:
@@ -30,7 +29,7 @@ detection:
         - 'form data-dojo-attach-point="containerNode" data-dojo-attach-event="onreset:_onReset,onsubmit:_onSubmit" name="frmLogin" lang="es" id="frmLogin" method="post" action="sg1.php" accept-charset="UTF-8" widgetid="frmLogin" style="margin: 0px;"'
 
 
-    condition: headerCapitalization and dojoJS and title and form
+    condition: csrf and dojoJS and title and form
 
 tags:
   - kit

--- a/indicators/credicorp-bank-tgeblg.yml
+++ b/indicators/credicorp-bank-tgeblg.yml
@@ -1,0 +1,38 @@
+title: Credicorp Bank Phishing Kit tGeBlg
+description: |
+    Detects a phishing kit targeting Credicorp Bank.
+    This was found as a result of this kit being deployed on Replit.
+
+
+references:
+    - https://www.credicorpbank.com/
+    - https://urlscan.io/result/c3582f08-595f-4796-8cb6-a794fdf13c2d/
+    - https://urlscan.io/result/5fc51b7e-6122-427b-9d06-c8e6f16f4b8f/
+    - https://urlscan.io/result/2684e40f-2619-46b9-9206-1fdb2e57b38a/
+
+detection:
+
+    headerCapitalization:
+      html|contains|all:
+        - meta http-equiv="CACHE-CONTROL" content="NO-CACHE"
+        - meta http-equiv="PRAGMA" content="NO-CACHE"
+
+    dojoJS:
+      html|contains:
+        - "src=\"js/dojo.js.descarga\" djconfig=\"parseOnLoad: true,modulePaths: {'dwr': '../../../../dwr-cache/2207051811','ec':'../ec'},fisaTheme:'fisaDesert', isContext:false\""
+
+    title:
+      html|contains:
+        - <title>CREDICORP BANK</title>
+
+    form:
+      html|contains:
+        - 'form data-dojo-attach-point="containerNode" data-dojo-attach-event="onreset:_onReset,onsubmit:_onSubmit" name="frmLogin" lang="es" id="frmLogin" method="post" action="sg1.php" accept-charset="UTF-8" widgetid="frmLogin" style="margin: 0px;"'
+
+
+    condition: headerCapitalization and dojoJS and title and form
+
+tags:
+  - kit
+  - target.credicorp_bank
+  - target_country.panama


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Creator**

✅ Indicator matches **3**/**3** referenced Urlscan results.

ID: `credicorp-bank-tgeblg`
Title: `Credicorp Bank Phishing Kit tGeBlg`
Description:
```
Detects a phishing kit targeting Credicorp Bank.
This was found as a result of this kit being deployed on Replit.
```
References:
https://www.credicorpbank.com/
https://urlscan.io/result/c3582f08-595f-4796-8cb6-a794fdf13c2d/
https://urlscan.io/result/5fc51b7e-6122-427b-9d06-c8e6f16f4b8f/
https://urlscan.io/result/2684e40f-2619-46b9-9206-1fdb2e57b38a/
Tags: `kit`, `target.credicorp_bank`, `target_country.panama` (🇵🇦)
Screenshot:
<img src="https://urlscan.io/screenshots/c3582f08-595f-4796-8cb6-a794fdf13c2d.png" width="800" height="600" />