### PR TITLE
Create indicator: Bancolombia Phishing Kit ZLbZ6V

### DIFF
--- a/indicators/bancolombia-zlbz6v.yml
+++ b/indicators/bancolombia-zlbz6v.yml
@@ -1,0 +1,41 @@
+title: Bancolombia Phishing Kit ZLbZ6V
+description: |
+    Detects a phishing kit targeting Bancolombia.
+    This was found as a result of this kit being deployed on Replit.
+
+
+references:
+    - https://urlscan.io/result/96c5759d-e22e-4ce4-838c-50b57bcb9b9b/
+    - https://urlscan.io/result/4dc26a9b-25c2-4f9a-87da-6709f0510a79/
+    - https://urlscan.io/result/aff4ce4f-b5c0-4053-b74d-1e9e8c1295df/
+    - https://urlscan.io/result/3b7b5d9b-dea0-498e-a064-6d7d64fdfb56/
+    - https://urlscan.io/result/8a6095f2-bd3c-47b9-a174-20625ba444a7/
+
+detection:
+
+    title:
+      html|contains:
+        - <title>home</title>
+
+    images:
+      requests|contains|all:
+        - imagenarrib.png
+        - imagenuno.png
+        - imagendos.png
+        - imagentres.png
+
+    textInput:
+      html|contains:
+        - input type="text" name="primero"
+
+    passwordInput:
+      html|contains:
+        - input type="password" maxlength="4" minlength="4" name="segundo"
+
+
+    condition: title and images and textInput and passwordInput
+
+tags:
+  - kit
+  - target.bancolombia
+  - target_country.colombia


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Creator**

✅ Indicator matches **5**/**5** referenced Urlscan results.

ID: `bancolombia-zlbz6v`
Title: `Bancolombia Phishing Kit ZLbZ6V`
Description:
```
Detects a phishing kit targeting Bancolombia.
This was found as a result of this kit being deployed on Replit.
```
References:
https://urlscan.io/result/96c5759d-e22e-4ce4-838c-50b57bcb9b9b/
https://urlscan.io/result/4dc26a9b-25c2-4f9a-87da-6709f0510a79/
https://urlscan.io/result/aff4ce4f-b5c0-4053-b74d-1e9e8c1295df/
https://urlscan.io/result/3b7b5d9b-dea0-498e-a064-6d7d64fdfb56/
https://urlscan.io/result/8a6095f2-bd3c-47b9-a174-20625ba444a7/
Tags: `kit`, `target.bancolombia`, `target_country.colombia` (🇨🇴)
Screenshot:
<img src="https://urlscan.io/screenshots/96c5759d-e22e-4ce4-838c-50b57bcb9b9b.png" width="800" height="600" />