### PR TITLE
Create indicator: Instagram Phishing Kit Ag0sOJ

### DIFF
--- a/indicators/instagram-ag0soj.yml
+++ b/indicators/instagram-ag0soj.yml
@@ -1,0 +1,35 @@
+title: Instagram Phishing Kit Ag0sOJ
+description: |
+    Detects a phishing kit targeting Instagram. Talks to "hizliresim.com" to fetch an image.
+    Commonly deployed on Freenom domains.
+
+
+references:
+    - https://urlscan.io/result/73dcc5cc-f6a2-4ed6-a924-bfad336eb83c/
+    - https://urlscan.io/result/ad3ac1dd-da2d-4bfe-b879-286843bf5de6/
+    - https://urlscan.io/result/5085f9ce-15a9-4f26-b488-b0889cb5f83b/
+
+detection:
+
+    css:
+      requests|contains|all:
+        - bootstrap.min.css
+        - material-design-iconic-font.min.css
+        - util.css
+        - main.css
+        - all.css
+
+    logo:
+      html|contains:
+        - img src="images/logo.svg" width="80"
+
+    img:
+      html|contains:
+        - img src="https://i.hizliresim.com
+
+
+    condition: css and logo and img
+
+tags:
+  - kit
+  - target.instagram


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Creator**

✅ Indicator matches **3**/**3** referenced Urlscan results.

ID: `instagram-ag0soj`
Title: `Instagram Phishing Kit Ag0sOJ`
Description:
```
Detects a phishing kit targeting Instagram. Talks to "hizliresim.com" to fetch an image.
Commonly deployed on Freenom domains.
```
References:
https://urlscan.io/result/73dcc5cc-f6a2-4ed6-a924-bfad336eb83c/
https://urlscan.io/result/ad3ac1dd-da2d-4bfe-b879-286843bf5de6/
https://urlscan.io/result/5085f9ce-15a9-4f26-b488-b0889cb5f83b/
Tags: `kit`, `target.instagram`
Screenshot:
<img src="https://urlscan.io/screenshots/73dcc5cc-f6a2-4ed6-a924-bfad336eb83c.png" width="800" height="600" />