### PR TITLE
Create indicator: Office 365 Phishing Kit l03TtM

### DIFF
--- a/indicators/office-365-l03ttm.yml
+++ b/indicators/office-365-l03ttm.yml
@@ -1,0 +1,30 @@
+title: Office 365 Phishing Kit l03TtM
+description: |
+    Detects a phishing kit targeting Office 365 using a fake login form.
+    It doesn't attempt to visually mimic the official login pages, allowing it to evade common detection engines.
+
+
+references:
+    - https://urlscan.io/result/aa88b424-2850-467e-9df1-1a92028e198e/
+    - https://urlscan.io/result/94ed86b6-2656-4a29-81e8-e60445a15fb7/
+
+detection:
+
+    headId:
+      html|contains:
+        - head id="ctl00_Head1"
+
+    background:
+      html|contains:
+        - 'background: url(https://ssomedialax.rapmls.com/backgrounds/bak.jpg)'
+
+    copyright:
+      html|contains:
+        - Copyright © 2020 Office365 Corporation. All rights reserved.
+
+
+    condition: headId and background and copyright
+
+tags:
+  - kit
+  - target.office365


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Creator**

✅ Indicator matches **2**/**2** referenced Urlscan results.

ID: `office-365-l03ttm`
Title: `Office 365 Phishing Kit l03TtM`
Description:
```
Detects a phishing kit targeting Office 365 using a fake login form.
It doesn't attempt to visually mimic the official login pages, allowing it to evade common detection engines.
```
References:
https://urlscan.io/result/aa88b424-2850-467e-9df1-1a92028e198e/
https://urlscan.io/result/94ed86b6-2656-4a29-81e8-e60445a15fb7/
Tags: `kit`, `target.office365`
Screenshot:
<img src="https://urlscan.io/screenshots/aa88b424-2850-467e-9df1-1a92028e198e.png" width="800" height="600" />