### PR TITLE
Create indicator: Instagram Appeal Phishing Kit 510EMm

### DIFF
--- a/indicators/instagram-apeal-510emm.yml
+++ b/indicators/instagram-apeal-510emm.yml
@@ -1,0 +1,30 @@
+title: Instagram Apeal Phishing Kit 510EMm
+description: |
+    Detects a phishing kit targeting Instagram by impersonating Instagram staff and tricking the user into filling out a fake appeal form.
+
+
+references:
+    - https://i.imgur.com/fv7nXjX.png
+    - https://urlscan.io/result/4a87ebf6-8e33-42d6-94b9-87b0035184aa/
+    - https://urlscan.io/result/799fc14b-9551-4875-8806-d2a97354586a/
+
+detection:
+
+    emptyTitle:
+      html|contains:
+        - <title></title>
+
+    backgroundVideo:
+      html|contains:
+        - <video width="100%" src="imgs/arka.mp4" autoplay="" muted="" loop=""></video>
+
+    language:
+      html|contains:
+        - <p>Language English (US)</p>
+
+
+    condition: emptyTitle and backgroundVideo and language
+
+tags:
+  - kit
+  - target.instagram

--- a/indicators/instagram-apeal-510emm.yml
+++ b/indicators/instagram-apeal-510emm.yml
@@ -1,4 +1,4 @@
-title: Instagram Apeal Phishing Kit 510EMm
+title: Instagram Appeal Phishing Kit 510EMm
 description: |
     Detects a phishing kit targeting Instagram by impersonating Instagram staff and tricking the user into filling out a fake appeal form.
 


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Creator**

✅ Indicator matches **2**/**2** referenced Urlscan results.

ID: `instagram-appeal-510emm`
Title: `Instagram Appeal Phishing Kit 510EMm`
Description:
```
Detects a phishing kit targeting Instagram by impersonating Instagram staff and tricking the user into filling out a fake appeal form.
```
References:
https://i.imgur.com/fv7nXjX.png
https://urlscan.io/result/4a87ebf6-8e33-42d6-94b9-87b0035184aa/
https://urlscan.io/result/799fc14b-9551-4875-8806-d2a97354586a/
Tags: `kit`, `target.instagram`
Screenshot:
<img src="https://urlscan.io/screenshots/4a87ebf6-8e33-42d6-94b9-87b0035184aa.png" width="800" height="600" />