### PR TITLE
Create indicator: Facebook Appeal Phishing Kit lf46pH

### DIFF
--- a/indicators/facebook-appeal-lf46ph.yml
+++ b/indicators/facebook-appeal-lf46ph.yml
@@ -14,7 +14,7 @@ detection:
 
     caseNumber:
       html|contains:
-        - Case Number: <a>#1008501933214</a>
+        - "Case Number: <a>#1008501933214</a>"
 
     title:
       html|contains:

--- a/indicators/facebook-appeal-lf46ph.yml
+++ b/indicators/facebook-appeal-lf46ph.yml
@@ -12,10 +12,9 @@ references:
 
 detection:
 
-    protection:
-      html|contains|all:
-        - function mousedwn(e)
-        - window.addEventListener("keydown",function(e)
+    caseNumber:
+      html|contains:
+        - Case Number: <a>#1008501933214</a>
 
     title:
       html|contains:
@@ -31,7 +30,7 @@ detection:
         - form action="process.php?button_location=settings&amp;button_name=addpay" method="POST"
 
 
-    condition: protection and title and dateGenerator and form
+    condition: caseNumber and title and dateGenerator and form
 
 tags:
   - kit

--- a/indicators/facebook-appeal-lf46ph.yml
+++ b/indicators/facebook-appeal-lf46ph.yml
@@ -1,0 +1,38 @@
+title: Facebook Appeal Phishing Kit lf46pH
+description: |
+    Detects a phishing kit targeting Facebook by tricking users into filling out a fake Community Standards violation appeal form.
+
+
+references:
+    - https://urlscan.io/result/93543e89-756e-4baa-8201-72d75943b421/
+    - https://urlscan.io/result/bea1dc69-a55c-4d5d-a2bd-ca6da51bafa7/
+    - https://urlscan.io/result/b998e7ed-92e8-45ef-af4c-1f5fc38fb968/
+    - https://urlscan.io/result/cf35e2a2-e4cd-4ff3-a573-f900bfb18f95/
+    - https://urlscan.io/search/#hash%3Af467a3a908fdedcb8af1cfb80bed6f6e990b021945ad10247f2b94294ffcbb0f
+
+detection:
+
+    protection:
+      html|contains|all:
+        - function mousedwn(e)
+        - window.addEventListener("keydown",function(e)
+
+    title:
+      html|contains:
+        - <title>Restrictions Information</title>
+
+    dateGenerator:
+      html|contains|all:
+        - var tanggallengkap = new String();
+        - var namahari = ("Minggu Senin Selasa Rabu Kamis Jumat Sabtu");
+
+    form:
+      html|contains:
+        - form action="process.php?button_location=settings&amp;button_name=addpay" method="POST"
+
+
+    condition: protection and title and dateGenerator and form
+
+tags:
+  - kit
+  - target.facebook


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Creator**

✅ Indicator matches **4**/**4** referenced Urlscan results.

ID: `facebook-appeal-lf46ph`
Title: `Facebook Appeal Phishing Kit lf46pH`
Description:
```
Detects a phishing kit targeting Facebook by tricking users into filling out a fake Community Standards violation appeal form.
```
References:
https://urlscan.io/result/93543e89-756e-4baa-8201-72d75943b421/
https://urlscan.io/result/bea1dc69-a55c-4d5d-a2bd-ca6da51bafa7/
https://urlscan.io/result/b998e7ed-92e8-45ef-af4c-1f5fc38fb968/
https://urlscan.io/result/cf35e2a2-e4cd-4ff3-a573-f900bfb18f95/
https://urlscan.io/search/#hash%3Af467a3a908fdedcb8af1cfb80bed6f6e990b021945ad10247f2b94294ffcbb0f
Tags: `kit`, `target.facebook`
Screenshot:
<img src="https://urlscan.io/screenshots/93543e89-756e-4baa-8201-72d75943b421.png" width="800" height="600" />