### PR TITLE
Create indicator: Banco de Galicia Phishing Kit 2mO4SF

### DIFF
--- a/indicators/banco-de-galicia-2mo4sf.yml
+++ b/indicators/banco-de-galicia-2mo4sf.yml
@@ -20,8 +20,12 @@ detection:
       html|contains:
         - form action="send.php" method="post" id="form1" onkeypress="return evalEnter(event);" autocomplete="off"
 
+    csrf:
+      html|contains:
+        - input name="__RequestVerificationToken" type="hidden" value="NOkPDuCJE_NXUBMT9OQG-KhVO3-R8Uruo-giLM1tLPZAsdDMuxuWaFsp-kpbIt1CHFjZx6z644GVwxBiB9gp6U0zaZWoM_pAGYsQZLEfUM01"
 
-    condition: malformedHTML and banner and form
+
+    condition: malformedHTML and banner and form and csrf
 
 tags:
   - kit

--- a/indicators/banco-de-galicia-2mo4sf.yml
+++ b/indicators/banco-de-galicia-2mo4sf.yml
@@ -1,0 +1,29 @@
+title: Banco de Galicia Phishing Kit 2mO4SF
+description: |
+    Detects a phishing kit targeting Banco de Galicia. The threat actor operates from Argentina itself.
+
+
+references:
+    - https://urlscan.io/result/d432c567-d1de-4b56-9ddb-af47248ab423/
+
+detection:
+
+    malformedHTML:
+      html|contains:
+        - <img src="img/109.jpg" width="100%" <title="">
+
+    banner:
+      html|contains:
+        - div class="logo_login" role="banner" data-automation-id="galicia-banner"
+
+    form:
+      html|contains:
+        - form action="send.php" method="post" id="form1" onkeypress="return evalEnter(event);" autocomplete="off"
+
+
+    condition: malformedHTML and banner and form
+
+tags:
+  - kit
+  - target.banco_de_galicia
+  - target_country.argentina


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Creator**

✅ Indicator matches **1**/**1** referenced Urlscan results.

ID: `banco-de-galicia-2mo4sf`
Title: `Banco de Galicia Phishing Kit 2mO4SF`
Description:
```
Detects a phishing kit targeting Banco de Galicia. The threat actor operates from Argentina itself.
```
References:
https://urlscan.io/result/d432c567-d1de-4b56-9ddb-af47248ab423/
Tags: `kit`, `target.banco_de_galicia`, `target_country.argentina` (🇦🇷)
Screenshot:
<img src="https://urlscan.io/screenshots/d432c567-d1de-4b56-9ddb-af47248ab423.png" width="800" height="600" />