### PR TITLE
Create indicator: Instragram Copyright Phishing Kit kVRJSB

### DIFF
--- a/indicators/instragram-copyright-kvrjsb.yml
+++ b/indicators/instragram-copyright-kvrjsb.yml
@@ -1,0 +1,46 @@
+title: Instragram Copyright Phishing Kit kVRJSB
+description: |
+    Detects a phishing kit targeting Instagram (Meta) by tricking users into filling out a fake copyright appeal form.
+    Threat actors observed in:
+    - Turkey 🇹🇷 (TT_MOBIL 20978; TTNET 9121; TURKCELL-AS 16135; VODAFONETURKEY 15897)
+    - France 🇫🇷 (SECFIREWALLAS 206092)
+
+
+references:
+    - https://urlscan.io/result/16895faa-8c3c-4a34-9016-ed991a491d39/
+    - https://urlscan.io/result/4c9626fc-29a5-4208-bbc4-5406ce71de73/
+    - https://urlscan.io/result/ec903627-adf8-4583-bda5-d2de6c27ef1d/
+    - https://urlscan.io/result/4af5fa50-6573-4421-9314-9c93c523d601/
+    - https://urlscan.io/result/d16a13ce-8602-4d26-a803-11fb4a0bd650/
+    - https://urlscan.io/result/893e4542-49d8-4fcb-93ff-fddd76689fea/
+    - https://urlscan.io/result/b614d724-2d16-4b99-9212-49315b6ca668/
+
+detection:
+
+    og:
+      html|contains|all:
+        - meta property="og:title"
+        - meta property="og:description"
+        - meta property="og:image"
+
+    sideImage:
+      html|contains:
+        - img src="./assets/images/img.svg" alt=""
+
+    containers:
+      html|contains|all:
+        - div class="login-container"
+        - div class="div1"
+        - div class="form-control"
+
+    form:
+      html|contains:
+        - form class="login-form" method="post"
+
+
+    condition: og and sideImage and containers and form
+
+tags:
+  - kit
+  - target.instagram
+  - target.meta


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Creator**

✅ Indicator matches **7**/**7** referenced Urlscan results.

ID: `instragram-copyright-kvrjsb`
Title: `Instragram Copyright Phishing Kit kVRJSB`
Description:
```
Detects a phishing kit targeting Instagram (Meta) by tricking users into filling out a fake copyright appeal form.
Threat actors observed in:
- Turkey 🇹🇷 (TT_MOBIL 20978; TTNET 9121; TURKCELL-AS 16135; VODAFONETURKEY 15897)
- France 🇫🇷 (SECFIREWALLAS 206092)
```
References:
https://urlscan.io/result/16895faa-8c3c-4a34-9016-ed991a491d39/
https://urlscan.io/result/4c9626fc-29a5-4208-bbc4-5406ce71de73/
https://urlscan.io/result/ec903627-adf8-4583-bda5-d2de6c27ef1d/
https://urlscan.io/result/4af5fa50-6573-4421-9314-9c93c523d601/
https://urlscan.io/result/d16a13ce-8602-4d26-a803-11fb4a0bd650/
https://urlscan.io/result/893e4542-49d8-4fcb-93ff-fddd76689fea/
https://urlscan.io/result/b614d724-2d16-4b99-9212-49315b6ca668/
Tags: `kit`, `target.instagram`, `target.meta`
Screenshot:
<img src="https://urlscan.io/screenshots/16895faa-8c3c-4a34-9016-ed991a491d39.png" width="800" height="600" />