### PR TITLE
Create indicator: Bancolombia Phishing Kit jr5mnv

### DIFF
--- a/indicators/bancolombia-jr5mnv.yml
+++ b/indicators/bancolombia-jr5mnv.yml
@@ -14,26 +14,22 @@ references:
 
 detection:
 
-    bootstrap:
-      html|contains:
-        - link rel="stylesheet" href="bootstrap.min.css"
-
-    containers:
-      html|contains|all:
-        - div class="limiter"
-        - div class="imgtopd"
+    icons:
+      css|contains|all:
+        - https://i.imgur.com/8Ezt3Uy.png
+        - https://i.imgur.com/KROsJQP.png
 
     images:
       html|contains|all:
-        - img src="toplogpro
-        - img src="info.png
+        - img src="toplogpro1.png"
+        - img src="info.png"
 
     form:
       html|contains:
         - form class="login100-form validate-form" method="post" action="rol.php"
 
 
-    condition: bootstrap and containers and images and form
+    condition: icons and images and form
 
 tags:
   - kit

--- a/indicators/bancolombia-jr5mnv.yml
+++ b/indicators/bancolombia-jr5mnv.yml
@@ -1,0 +1,41 @@
+title: Bancolombia Phishing Kit jr5mnv
+description: |
+    Detects a phishing kit targeting Bancolombia.
+    This was found as a result of this kit being deployed on Replit.
+
+
+references:
+    - https://urlscan.io/result/b4501b15-b767-4c10-a11e-898ae8cf01a7/
+    - https://urlscan.io/result/185193df-05e6-40ff-aa2e-694098a4f03a/
+    - https://urlscan.io/result/2759a513-0dee-49e5-8dfb-820b1acea250/
+    - https://urlscan.io/result/1d52da2c-126c-4a99-bfde-c8a11c2a1a12/
+    - https://urlscan.io/result/e577760c-3901-4fd3-93c4-58a9e2613250/
+    - https://urlscan.io/result/500c35f2-ca7e-4673-8cf0-19a5f686547f/
+
+detection:
+
+    bootstrap:
+      html|contains:
+        - link rel="stylesheet" href="bootstrap.min.css"
+
+    containers:
+      html|contains|all:
+        - div class="limiter"
+        - div class="imgtopd"
+
+    images:
+      html|contains|all:
+        - img src="toplogpro
+        - img src="info.png
+
+    form:
+      html|contains:
+        - form class="login100-form validate-form" method="post" action="rol.php"
+
+
+    condition: bootstrap and containers and images and form
+
+tags:
+  - kit
+  - target.bancolombia
+  - target_country.colombia


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Creator**

✅ Indicator matches **6**/**6** referenced Urlscan results.

ID: `bancolombia-jr5mnv`
Title: `Bancolombia Phishing Kit jr5mnv`
Description:
```
Detects a phishing kit targeting Bancolombia.
This was found as a result of this kit being deployed on Replit.
```
References:
https://urlscan.io/result/b4501b15-b767-4c10-a11e-898ae8cf01a7/
https://urlscan.io/result/185193df-05e6-40ff-aa2e-694098a4f03a/
https://urlscan.io/result/2759a513-0dee-49e5-8dfb-820b1acea250/
https://urlscan.io/result/1d52da2c-126c-4a99-bfde-c8a11c2a1a12/
https://urlscan.io/result/e577760c-3901-4fd3-93c4-58a9e2613250/
https://urlscan.io/result/500c35f2-ca7e-4673-8cf0-19a5f686547f/
Tags: `kit`, `target.bancolombia`, `target_country.colombia` (🇨🇴)
Screenshot:
<img src="https://urlscan.io/screenshots/b4501b15-b767-4c10-a11e-898ae8cf01a7.png" width="800" height="600" />