### PR TITLE
Create indicator: Banco de Crédito del Perú (BCP) Phishing Kit XEjFkd

### DIFF
--- a/indicators/banco-de-crédito-del-perú-xejfkd.yml
+++ b/indicators/banco-de-crédito-del-perú-xejfkd.yml
@@ -1,0 +1,38 @@
+title: Banco de Crédito del Perú (BCP) Phishing Kit XEjFkd
+description: |
+    Detects a phishing kit targeting Banco de Crédito del Perú (BCP). BCP is the largest bank in Peru.
+    This was found as a result of this kit being deployed on Replit.
+
+
+references:
+    - https://urlscan.io/result/bf07a311-9c17-4538-8396-2b2cd7b1a917/
+    - https://urlscan.io/result/a17da382-1ace-4012-9a81-06eab1c365d2/
+    - https://urlscan.io/result/e993630d-6656-47ee-871e-c970ebda7e09/
+
+detection:
+
+    title:
+      html|contains:
+        - <title>Banco de Crédito BCP</title>
+
+    css:
+      html|contains|all:
+        - link href="./data/style.css" rel="stylesheet"
+        - link href="./data/main.css" rel="stylesheet"
+
+    form:
+      html|contains:
+        - form action="./data/carga.php"
+
+    backgroundImage:
+      html|contains:
+        - 'background-image: url(./data/bcpFondoLogin.jpg);'
+
+
+    condition: title and css and form and backgroundImage
+
+tags:
+  - kit
+  - target.bcp
+  - target.banco_de_credito_del_peru
+  - target_country.peru

--- a/indicators/banco-de-crédito-del-perú-xejfkd.yml
+++ b/indicators/banco-de-crédito-del-perú-xejfkd.yml
@@ -15,10 +15,13 @@ detection:
       html|contains:
         - <title>Banco de Crédito BCP</title>
 
-    css:
-      html|contains|all:
-        - link href="./data/style.css" rel="stylesheet"
-        - link href="./data/main.css" rel="stylesheet"
+    originTrialToken:
+      html|contains:
+        - meta http-equiv="origin-trial" content="A751Xsk4ZW3DVQ8WZng2Dk5s3YzAyqncTzgv+VaE6wavgTY0QHkDvUTET1o7HanhuJO8lgv1Vvc88Ij78W1FIAAAAAB7eyJvcmlnaW4iOiJodHRwczovL3d3dy5nb29nbGV0YWdtYW5hZ2VyLmNvbTo0NDMiLCJmZWF0dXJlIjoiUHJpdmFjeVNhbmRib3hBZHNBUElzIiwiZXhwaXJ5IjoxNjgwNjUyNzk5LCJpc1RoaXJkUGFydHkiOnRydWV9"
+
+    uniqueTextFile:
+      html|contains:
+        - script type="text/javascript" async="" src="./data/f.txt"
 
     form:
       html|contains:
@@ -29,7 +32,7 @@ detection:
         - 'background-image: url(./data/bcpFondoLogin.jpg);'
 
 
-    condition: title and css and form and backgroundImage
+    condition: title and originTrialToken and uniqueTextFile and form and backgroundImage
 
 tags:
   - kit


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Creator**

✅ Indicator matches **3**/**3** referenced Urlscan results.

ID: `banco-de-crédito-del-perú-xejfkd`
Title: `Banco de Crédito del Perú (BCP) Phishing Kit XEjFkd`
Description:
```
Detects a phishing kit targeting Banco de Crédito del Perú (BCP). BCP is the largest bank in Peru.
This was found as a result of this kit being deployed on Replit.
```
References:
https://urlscan.io/result/bf07a311-9c17-4538-8396-2b2cd7b1a917/
https://urlscan.io/result/a17da382-1ace-4012-9a81-06eab1c365d2/
https://urlscan.io/result/e993630d-6656-47ee-871e-c970ebda7e09/
Tags: `kit`, `target.bcp`, `target.banco_de_credito_del_peru`, `target_country.peru` (🇵🇪)
Screenshot:
<img src="https://urlscan.io/screenshots/bf07a311-9c17-4538-8396-2b2cd7b1a917.png" width="800" height="600" />