### PR TITLE
Create indicator: Discord/Steam Phishing Kit jIwQMP

### DIFF
--- a/indicators/discord-steam-jiwqmp.yml
+++ b/indicators/discord-steam-jiwqmp.yml
@@ -1,0 +1,29 @@
+title: Discord/Steam Phishing Kit jIwQMP
+description: |
+    Detects a phishing kit impersonating Discord and targeting Steam with a fake popup that opens when the "Get Nitro" button is clicked. The site promises to give you a free Discord Nitro subscription.
+    This phishing kit has been discovered by the FishFish.gg team.
+
+
+references:
+    - https://urlscan.io/result/7d69a2f2-047e-4e82-89ed-bac9d322c662/
+
+detection:
+
+    title:
+      html|contains:
+        - <title>Free Discord Nitro from Steam</title>
+
+    css:
+      html|contains|all:
+        - link href="/c29e212f2e1d1360ad262d5e56437edf69d4b16111c5/6fce5123c54fab983c7d6685168525c2d9f7f5f5f161.css" rel="stylesheet"
+        - link href="/c29e212f2e1d1360ad262d5e56437edf69d4b16111c5/609e858fb15ecb308dd736273f0c5a23e7ef90a6d7ed.css" rel="stylesheet"
+        - link href="/c29e212f2e1d1360ad262d5e56437edf69d4b16111c5/800e2135483e49ce84fedb4c685bdc1e6065fea8f5e0.css" rel="stylesheet"
+        - link href="/c29e212f2e1d1360ad262d5e56437edf69d4b16111c5/03269d738aed6b1925fa085ad5427e1dddd8a5144b09.css" rel="stylesheet"
+        - link href="/c29e212f2e1d1360ad262d5e56437edf69d4b16111c5/4cd84e662b43c81f546a50a0df62bffa39a7a13915e4.css" rel="stylesheet"
+
+
+    condition: title and css
+
+tags:
+  - kit
+  - target.discord

--- a/indicators/steam-jiwqmp.yml
+++ b/indicators/steam-jiwqmp.yml
@@ -1,8 +1,9 @@
-title: Discord/Steam Phishing Kit jIwQMP
+title: Steam Phishing Kit jIwQMP
 description: |
-    Detects a phishing kit impersonating Discord and targeting Steam with a fake popup that opens when the "Get Nitro" button is clicked. The site promises to give you a free Discord Nitro subscription.
+    Detects a phishing kit impersonating Discord and targeting Steam users with a fake popup that opens when the "Get Nitro" button is clicked. 
+    The site promises to give you a free Discord Nitro subscription upon entering your Steam credentials.
+    
     This phishing kit has been discovered by the FishFish.gg team.
-
 
 references:
     - https://urlscan.io/result/7d69a2f2-047e-4e82-89ed-bac9d322c662/
@@ -27,3 +28,4 @@ detection:
 tags:
   - kit
   - target.discord
+  - target.steam


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Creator**

✅ Indicator matches **1**/**1** referenced Urlscan results.

ID: `discord-steam-jiwqmp`
Title: `Discord/Steam Phishing Kit jIwQMP`
Description:
```
Detects a phishing kit impersonating Discord and targeting Steam with a fake popup that opens when the "Get Nitro" button is clicked. The site promises to give you a free Discord Nitro subscription.
This phishing kit has been discovered by the FishFish.gg team.
```
References:
https://urlscan.io/result/7d69a2f2-047e-4e82-89ed-bac9d322c662/
Tags: `kit`, `target.discord`
Screenshot:
<img src="https://urlscan.io/screenshots/7d69a2f2-047e-4e82-89ed-bac9d322c662.png" width="800" height="600" />