### PR TITLE
Create indicator: Banco Agrario de Colombia Phishing Kit dWzjXc

### DIFF
--- a/indicators/banco-agrario-de-colombia-dwzjxc.yml
+++ b/indicators/banco-agrario-de-colombia-dwzjxc.yml
@@ -1,0 +1,31 @@
+title: Banco Agrario de Colombia Phishing Kit dWzjXc
+description: |
+    Detects a phishing kit targeting Banco Agrario de Colombia.
+    This was found as a result of this kit being deployed on Replit.
+
+
+references:
+    - https://ebanking.bancoagrario.gov.co/BA.ICBanking.WebUI/
+    - https://urlscan.io/result/e157f0ff-a6fe-45aa-8900-a0c8730d3272/
+
+detection:
+
+    title:
+      html|contains:
+        - <title>Banco Agrario de Colombia</title>
+
+    form:
+      html|contains:
+        - form method="post" action="index2.php" onsubmit="javascript:return WebForm_OnSubmit();" id="ctl01"
+
+    css:
+      html|contains:
+        - link rel="stylesheet" type="text/css" href="https://digital.bancoagrario.gov.co:443/sdk/stylesheets/prismaWeb.css?v=7.0.995&amp;_=1640181081"
+
+
+    condition: title and form and css
+
+tags:
+  - kit
+  - target.banco_agrario_de_colombia
+  - target_country.colombia


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Creator**

✅ Indicator matches **1**/**1** referenced Urlscan results.

ID: `banco-agrario-de-colombia-dwzjxc`
Title: `Banco Agrario de Colombia Phishing Kit dWzjXc`
Description:
```
Detects a phishing kit targeting Banco Agrario de Colombia.
This was found as a result of this kit being deployed on Replit.
```
References:
https://ebanking.bancoagrario.gov.co/BA.ICBanking.WebUI/
https://urlscan.io/result/e157f0ff-a6fe-45aa-8900-a0c8730d3272/
Tags: `kit`, `target.banco_agrario_de_colombia`, `target_country.colombia` (🇨🇴)
Screenshot:
<img src="https://urlscan.io/screenshots/e157f0ff-a6fe-45aa-8900-a0c8730d3272.png" width="800" height="600" />