### PR TITLE
Create indicator: Banco Santa Fe Phishing Kit

### DIFF
--- a/indicators/banco-santa-fe.yml
+++ b/indicators/banco-santa-fe.yml
@@ -1,0 +1,45 @@
+title: Banco Santa Fe Phishing Kit
+description: |
+    Detects a phishing kit targeting Banco Santa Fe.
+    This was found as a result of this kit being deployed on Replit.
+
+
+references:
+    - https://www.bancosantafe.com.ar
+    - https://urlscan.io/result/27cfbb88-d922-42d4-882a-cb18048ba0ff/
+    - https://urlscan.io/result/bc8dee32-12ed-40ab-96ee-336d25468aab/
+    - https://urlscan.io/result/4f849055-5bbb-4592-916c-fc991935464b/
+    - https://urlscan.io/result/b11bb25b-1bb6-405d-b9e7-8b169e9a5449/
+    - https://urlscan.io/result/c6186af8-9b40-444d-b997-5766a3acc185/
+    - https://urlscan.io/result/78ddacaf-05a6-4028-b039-baa2eca7c82d/
+    - https://urlscan.io/result/b63af6a1-458c-4b3f-8efb-f56d2e0976d7/
+    - https://urlscan.io/result/7f09de6c-4629-4ff0-a9de-276d0a131688/
+    - https://urlscan.io/result/c514ad84-3b57-44cf-9659-c6d5d90eb747/
+    - https://urlscan.io/result/baa04e11-a8e8-4ec8-a9d5-5155587f0965/
+
+detection:
+
+    css:
+      html|contains|all:
+        - link rel="stylesheet" href="css/normalize.min.css"
+        - link rel="stylesheet" data-href="https://fonts.googleapis.com/css?family=Rubik:400,700&amp;display=swap"
+
+    favicon:
+      html|contains:
+        - link rel="shortcut icon" href="/static/favicon-16x16.png"
+
+    title:
+      html|contains:
+        - <title>Banco Santa Fe</title>
+
+    form:
+      html|contains:
+        - form class="css-f1fhd9" action="db/loginStep1.php" method="POST"
+
+
+    condition: css and favicon and title and form
+
+tags:
+  - kit
+  - target.banco_santa_fe
+  - target_country.argentina

--- a/indicators/banco-santa-fe.yml
+++ b/indicators/banco-santa-fe.yml
@@ -19,14 +19,9 @@ references:
 
 detection:
 
-    css:
-      html|contains|all:
-        - link rel="stylesheet" href="css/normalize.min.css"
-        - link rel="stylesheet" data-href="https://fonts.googleapis.com/css?family=Rubik:400,700&amp;display=swap"
-
-    favicon:
+    googleTagManager:
       html|contains:
-        - link rel="shortcut icon" href="/static/favicon-16x16.png"
+        - 'script async="" src="https://www.googletagmanager.com/gtm.js?id=GTM-P3PQJJC"'
 
     title:
       html|contains:
@@ -37,7 +32,7 @@ detection:
         - form class="css-f1fhd9" action="db/loginStep1.php" method="POST"
 
 
-    condition: css and favicon and title and form
+    condition: googleTagManager and title and form
 
 tags:
   - kit


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Creator**

✅ Indicator matches **10**/**10** referenced Urlscan results.

ID: `banco-santa-fe`
Title: `Banco Santa Fe Phishing Kit`
Description:
```
Detects a phishing kit targeting Banco Santa Fe.
This was found as a result of this kit being deployed on Replit.
```
References:
https://www.bancosantafe.com.ar
https://urlscan.io/result/27cfbb88-d922-42d4-882a-cb18048ba0ff/
https://urlscan.io/result/bc8dee32-12ed-40ab-96ee-336d25468aab/
https://urlscan.io/result/4f849055-5bbb-4592-916c-fc991935464b/
https://urlscan.io/result/b11bb25b-1bb6-405d-b9e7-8b169e9a5449/
https://urlscan.io/result/c6186af8-9b40-444d-b997-5766a3acc185/
https://urlscan.io/result/78ddacaf-05a6-4028-b039-baa2eca7c82d/
https://urlscan.io/result/b63af6a1-458c-4b3f-8efb-f56d2e0976d7/
https://urlscan.io/result/7f09de6c-4629-4ff0-a9de-276d0a131688/
https://urlscan.io/result/c514ad84-3b57-44cf-9659-c6d5d90eb747/
https://urlscan.io/result/baa04e11-a8e8-4ec8-a9d5-5155587f0965/
Tags: `kit`, `target.banco_santa_fe`, `target_country.argentina` (🇦🇷)
Screenshot:
<img src="https://urlscan.io/screenshots/27cfbb88-d922-42d4-882a-cb18048ba0ff.png" width="800" height="600" />