### PR TITLE
Create indicator: Discord/Steam Phishing Kit 0BFMGg

### DIFF
--- a/indicators/discord-steam-0BFMGg.yml
+++ b/indicators/discord-steam-0BFMGg.yml
@@ -21,12 +21,10 @@ detection:
         - meta data-react-helmet="true" property="og:title" content="3 months of Discord Nitro free from STEAM"
         - meta data-react-helmet="true" property="og:description" content="Get 3 months of Discord Nitro free from STEAM. Upgrade your emoji, enjoy bigger file uploads, stand out in your favorite Discords, and more."
 
-    viewport:
-      html|contains:
-        - meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=no"
+    css:
+      css|contains: assets/images/bg.svg?v=7583b449
 
-
-    condition: title and embed and viewport
+    condition: title and embed and css
 
 tags:
   - kit

--- a/indicators/discord-steam-0BFMGg.yml
+++ b/indicators/discord-steam-0BFMGg.yml
@@ -1,0 +1,34 @@
+title: Discord/Steam Phishing Kit 0BFMGg
+description: |
+    Detects a phishing kit impersonating Discord and targeting Steam with a fake popup that opens when the "Get Nitro" button is clicked. The site promises to give you a free Discord Nitro subscription.
+    This phishing kit has been discovered by the FishFish.gg team.
+
+
+references:
+    - https://urlscan.io/result/a2bc1037-834a-4b09-8cba-81ad8850d053/
+    - https://urlscan.io/result/6e1af6f3-574d-465e-8ff9-2db5ba79f44a/
+    - https://urlscan.io/result/8cb54a81-49e5-430d-b504-283829a7fada/
+
+detection:
+
+    title:
+      html|contains:
+        - <title>Free Discord Nitro</title>
+
+    embed:
+      html|contains|all:
+        - meta name="description" content="Free Discord Nitro"
+        - meta data-react-helmet="true" property="og:title" content="3 months of Discord Nitro free from STEAM"
+        - meta data-react-helmet="true" property="og:description" content="Get 3 months of Discord Nitro free from STEAM. Upgrade your emoji, enjoy bigger file uploads, stand out in your favorite Discords, and more."
+
+    viewport:
+      html|contains:
+        - meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=no"
+
+
+    condition: title and embed and viewport
+
+tags:
+  - kit
+  - target.discord
+  - target.steam


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Creator**

✅ Indicator matches **3**/**3** referenced Urlscan results.

ID: `discord-steam-0BFMGg`
Title: `Discord/Steam Phishing Kit 0BFMGg`
Description:
```
Detects a phishing kit impersonating Discord and targeting Steam with a fake popup that opens when the "Get Nitro" button is clicked. The site promises to give you a free Discord Nitro subscription.
This phishing kit has been discovered by the FishFish.gg team.
```
References:
https://urlscan.io/result/a2bc1037-834a-4b09-8cba-81ad8850d053/
https://urlscan.io/result/6e1af6f3-574d-465e-8ff9-2db5ba79f44a/
https://urlscan.io/result/8cb54a81-49e5-430d-b504-283829a7fada/
Tags: `kit`, `target.discord`, `target.steam`
Screenshot:
<img src="https://urlscan.io/screenshots/a2bc1037-834a-4b09-8cba-81ad8850d053.png" width="800" height="600" />