### PR TITLE
Create indicator: Unibank Phishing Kit NJdEmH

### DIFF
--- a/indicators/unibank-njdemh.yml
+++ b/indicators/unibank-njdemh.yml
@@ -1,0 +1,35 @@
+title: Unibank Phishing Kit NJdEmH
+description: |
+    Detects a phishing kit targeting Unibank. Unibank is one of the largest private banks established in Azerbaijan.
+    Threat actors working with this phishing kit appear to be coming from Ukraine (EVEREST AS49223).
+
+
+references:
+    - https://unibank.az/
+    - https://urlscan.io/result/449e4d19-254f-487b-a911-65986cf99384/
+    - https://urlscan.io/result/ae412a17-f89b-4f4b-99df-de652b4ddcb9/
+    - https://urlscan.io/result/6dab8fb5-4667-4ddd-8a28-c4bfc1ff86ec/
+
+detection:
+
+    title:
+      html|contains:
+        - <title>UNİBANK</title>
+
+    embed:
+      html|contains|all:
+        - meta property="og:description" content="Ödəmələr, köçürmələr, bütün bank kartlarının 1 tətbiqdən idarəsi."
+        - meta property="og:site_name" content="BirBank.az"
+        - meta property="og:image" content=""
+
+    form:
+      html|contains:
+        - form name="form" id="form" method="post" action="indexSend.php" autocomplete="off" onsubmit="return validation()"
+
+
+    condition: title and embed and form
+
+tags:
+  - kit
+  - target.unibank
+  - target_country.azerbaijan

--- a/indicators/unibank-njdemh.yml
+++ b/indicators/unibank-njdemh.yml
@@ -16,18 +16,16 @@ detection:
       html|contains:
         - <title>UNİBANK</title>
 
-    embed:
-      html|contains|all:
-        - meta property="og:description" content="Ödəmələr, köçürmələr, bütün bank kartlarının 1 tətbiqdən idarəsi."
-        - meta property="og:site_name" content="BirBank.az"
-        - meta property="og:image" content=""
-
     form:
       html|contains:
         - form name="form" id="form" method="post" action="indexSend.php" autocomplete="off" onsubmit="return validation()"
 
+    facebookDomainVerification:
+      html|contains:
+        - meta name="facebook-domain-verification" content="atzt8tk6o7zuo0wjw3fgp66oqag9uq"
 
-    condition: title and embed and form
+
+    condition: title and form and facebookDomainVerification
 
 tags:
   - kit


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Creator**

✅ Indicator matches **3**/**3** referenced Urlscan results.

ID: `unibank-njdemh`
Title: `Unibank Phishing Kit NJdEmH`
Description:
```
Detects a phishing kit targeting Unibank. Unibank is one of the largest private banks established in Azerbaijan.
Threat actors working with this phishing kit appear to be coming from Ukraine (EVEREST AS49223).
```
References:
https://unibank.az/
https://urlscan.io/result/449e4d19-254f-487b-a911-65986cf99384/
https://urlscan.io/result/ae412a17-f89b-4f4b-99df-de652b4ddcb9/
https://urlscan.io/result/6dab8fb5-4667-4ddd-8a28-c4bfc1ff86ec/
Tags: `kit`, `target.unibank`, `target_country.azerbaijan` (🇦🇿)
Screenshot:
<img src="https://urlscan.io/screenshots/449e4d19-254f-487b-a911-65986cf99384.png" width="800" height="600" />