### PR TITLE
Create indicator: Tuya Redirect 4eWQNc

### DIFF
--- a/indicators/tuya-redirect-4ewqnc.yml
+++ b/indicators/tuya-redirect-4ewqnc.yml
@@ -13,8 +13,8 @@ detection:
     title:
       html|contains: Portal Transaccional
 
-    scriptSource:
-      html|contains: 'src="https://us-sonar.sociomantic.com/js/2010-07-01/adpan/tuya-co"'
+    function:
+      html|contains: onclick="insertclavex('0');"
 
     css:
       html|contains|all:
@@ -23,7 +23,7 @@ detection:
         - link href="App_Themes/404/bootstrap.min.css" rel="stylesheet"
 
 
-    condition: title and scriptSource and css
+    condition: title and function and css
 
 tags:
   - kit

--- a/indicators/tuya-redirect-4ewqnc.yml
+++ b/indicators/tuya-redirect-4ewqnc.yml
@@ -6,13 +6,15 @@ description: |
 
 references:
     - https://www.tuya.com.co/
-    - https://urlscan.io/result/026d1d48-ba58-477d-a168-0581ef8b9ebc/
+    - https://urlscan.io/result/630122d4-6b1b-4b56-bb13-6b6a1f28af4f/
 
 detection:
 
     title:
-      html|contains:
-        - Portal Transaccional
+      html|contains: Portal Transaccional
+
+    scriptSource:
+      html|contains: 'src="https://us-sonar.sociomantic.com/js/2010-07-01/adpan/tuya-co"'
 
     css:
       html|contains|all:
@@ -20,17 +22,8 @@ detection:
         - link href="App_Themes/404/Default1.css" type="text/css"
         - link href="App_Themes/404/bootstrap.min.css" rel="stylesheet"
 
-    form:
-      html|contains:
-        - form name="aspnetForm" method="post" action="
 
-    telegram:
-      html|contains|all:
-        - const token = '5670102107:AAGWzjd8rsaQb_KMkVQsCcgPB9o85gb_rXc';
-        - const chatId = '-1001617305508';
-
-
-    condition: title and css and form and telegram
+    condition: title and scriptSource and css
 
 tags:
   - kit

--- a/indicators/tuya-redirect-4ewqnc.yml
+++ b/indicators/tuya-redirect-4ewqnc.yml
@@ -1,0 +1,38 @@
+title: Tuya Redirect 4eWQNc
+description: |
+    Detects a phishing landing page for the Colombian bank and credit card issuer Tuya.
+    This was found as a result of this kit being deployed on Replit.
+
+
+references:
+    - https://www.tuya.com.co/
+    - https://urlscan.io/result/026d1d48-ba58-477d-a168-0581ef8b9ebc/
+
+detection:
+
+    title:
+      html|contains:
+        - Portal Transaccional
+
+    css:
+      html|contains|all:
+        - link href="App_Themes/404/bootstrap.min.css" type="text/css"
+        - link href="App_Themes/404/Default1.css" type="text/css"
+        - link href="App_Themes/404/bootstrap.min.css" rel="stylesheet"
+
+    form:
+      html|contains:
+        - form name="aspnetForm" method="post" action="
+
+    telegram:
+      html|contains|all:
+        - const token = '5670102107:AAGWzjd8rsaQb_KMkVQsCcgPB9o85gb_rXc';
+        - const chatId = '-1001617305508';
+
+
+    condition: title and css and form and telegram
+
+tags:
+  - kit
+  - target.tuya
+  - target_country.colombia


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Creator**

✅ Indicator matches **1**/**1** referenced Urlscan results.

ID: `tuya-redirect-4ewqnc`
Title: `Tuya Redirect 4eWQNc`
Description:
```
Detects a phishing landing page for the Colombian bank and credit card issuer Tuya.
This was found as a result of this kit being deployed on Replit.
```
References:
https://www.tuya.com.co/
https://urlscan.io/result/630122d4-6b1b-4b56-bb13-6b6a1f28af4f/

Tags: `kit`, `target.tuya`, `target_country.colombia` (🇨🇴)
Screenshot:
<img src="https://urlscan.io/screenshots/630122d4-6b1b-4b56-bb13-6b6a1f28af4f.png" width="800" height="600" />