### PR TITLE
Create indicator: Bank of America Phishing Kit kgzRkD

### DIFF
--- a/indicators/bank-of-america-kgzrkd.yml
+++ b/indicators/bank-of-america-kgzrkd.yml
@@ -1,0 +1,31 @@
+title: Bank of America Phishing Kit kgzRkD
+description: |
+    Detects a phishing kit targeting Bank of America. This kit is already detected by Urlscan.
+    Found as a result of it being deployed on Replit.
+
+
+references:
+    - https://urlscan.io/result/928c09f2-1a08-4a13-a76e-4c8c5e741063/
+
+detection:
+
+    title:
+      html|contains:
+        - <title>Bank of America | Online Banking | DebitCard Information</title>
+
+    css:
+      html|contains|all:
+        - .fondo{	background:url(prin.png);	background-repeat:no-repeat;	}
+        - .Sign #button:hover{background:url(BotonAzul.png)}
+
+    form:
+      html|contains:
+        - form method="post" action="conplas/sando.php" autocomplete="off"
+
+
+    condition: title and css and form
+
+tags:
+  - kit
+  - target.bankofamerica
+  - target_country.us

--- a/indicators/bank-of-america-kgzrkd.yml
+++ b/indicators/bank-of-america-kgzrkd.yml
@@ -6,6 +6,7 @@ description: |
 
 references:
     - https://urlscan.io/result/928c09f2-1a08-4a13-a76e-4c8c5e741063/
+    - https://urlscan.io/result/3377f34c-fa5a-4171-8ea4-6501c3b70c9b/
 
 detection:
 
@@ -16,7 +17,7 @@ detection:
     css:
       html|contains|all:
         - .fondo{	background:url(prin.png);	background-repeat:no-repeat;	}
-        - .Sign #button:hover{background:url(BotonAzul.png)}
+        - ".Sign #button:hover{background:url(BotonAzul.png)}"
 
     form:
       html|contains:


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Creator**

✅ Indicator matches **1**/**1** referenced Urlscan results.

ID: `bank-of-america-kgzrkd`
Title: `Bank of America Phishing Kit kgzRkD`
Description:
```
Detects a phishing kit targeting Bank of America. This kit is already detected by Urlscan.
Found as a result of it being deployed on Replit.
```
References:
https://urlscan.io/result/928c09f2-1a08-4a13-a76e-4c8c5e741063/
Tags: `kit`, `target.bankofamerica`, `target_country.us`
Screenshot:
<img src="https://urlscan.io/screenshots/928c09f2-1a08-4a13-a76e-4c8c5e741063.png" width="800" height="600" />