### PR TITLE
Create indicator: Credicorp Bank Phishing Kit Du47YO

### DIFF
--- a/indicators/credicorp-bank-du47yo.yml
+++ b/indicators/credicorp-bank-du47yo.yml
@@ -1,0 +1,32 @@
+title: Credicorp Bank Phishing Kit Du47YO
+description: |
+    Detects a different phishing kit targeting Credicorp Bank.
+    This was found as a result of this kit being deployed on Replit.
+
+
+references:
+    - https://urlscan.io/result/b916a5de-739a-4937-ae66-b1769b95cbd9/
+
+detection:
+
+    title:
+      html|contains:
+        - <title>CREDICORP</title>
+
+    css:
+      requests|contains|all:
+        - fisaDesertAll.css
+        - fisaDesertLogin.css
+        - fisaDesertLoginCustom.css
+
+    image:
+      html|contains:
+        - img src="./sonlosarchis/logo.png"
+
+
+    condition: title and css and image
+
+tags:
+  - kit
+  - target.credicorp_bank
+  - target_country.panama


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Creator**

✅ Indicator matches **1**/**1** referenced Urlscan results.

ID: `credicorp-bank-du47yo`
Title: `Credicorp Bank Phishing Kit Du47YO`
Description:
```
Detects a different phishing kit targeting Credicorp Bank.
This was found as a result of this kit being deployed on Replit.
```
References:
https://urlscan.io/result/b916a5de-739a-4937-ae66-b1769b95cbd9/
Tags: `kit`, `target.credicorp_bank`, `target_country.panama`
Screenshot:
<img src="https://urlscan.io/screenshots/b916a5de-739a-4937-ae66-b1769b95cbd9.png" width="800" height="600" />