### PR TITLE
Remove redundant detection string

### DIFF
--- a/indicators/toastrjs-crypto-drainer-0d0f9db.yml
+++ b/indicators/toastrjs-crypto-drainer-0d0f9db.yml
@@ -11,13 +11,10 @@ detection:
     fileName:
       requests|contains: 'toastr.js'
 
-    dataExfiltrationC2: 
-      js|contains: 'https://bootcs.com/gsql/'
-
     faviconSrc:
       html|contains: 'bootcs.com/fav.ico'
 
-    condition: fileName and dataExfiltrationC2 and faviconSrc
+    condition: fileName and faviconSrc
 
 tags:
   - cryptocurrency


### PR DESCRIPTION
Removes redundant detection string from `toastrjs-crypto-drainer-0d0f9db`