### PR TITLE
Dependency bump: Sigma-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module phish.report/IOK
 go 1.17
 
 require (
-	github.com/bradleyjkemp/sigma-go v0.3.3
+	github.com/bradleyjkemp/sigma-go v0.4.1
 	golang.org/x/net v0.0.0-20220630215102-69896b714898
 )
 
@@ -11,5 +11,5 @@ require (
 	github.com/PaesslerAG/gval v1.0.0 // indirect
 	github.com/PaesslerAG/jsonpath v0.1.1 // indirect
 	github.com/alecthomas/participle v0.7.1 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/bradleyjkemp/cupaloy/v2 v2.6.0 h1:knToPYa2xtfg42U3I6punFEjaGFKWQRXJwj
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/bradleyjkemp/sigma-go v0.3.3 h1:kbZ9Ce6yeLbqKaZ3otT4q1tkaLykzS0CxPsw76tdOgE=
 github.com/bradleyjkemp/sigma-go v0.3.3/go.mod h1:eDT0OXQD6U68UQXw4XXaRz38Lb/PwJ/BKVCaPQ0I5fA=
+github.com/bradleyjkemp/sigma-go v0.4.1 h1:uIvhR0SNSBq7bsR0nPtUc1fQZENX/J+Isd40aSQf7gE=
+github.com/bradleyjkemp/sigma-go v0.4.1/go.mod h1:eDT0OXQD6U68UQXw4XXaRz38Lb/PwJ/BKVCaPQ0I5fA=
 github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -37,3 +39,5 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Current version of sigma-go being used doesn't support `re` matcher which causes a panic when trying evaluate matches that use `re`.

Example rule using `re` matcher:
https://github.com/phish-report/IOK/blob/main/indicators/class-attribute-obfuscation.yml