### PR TITLE
Add three rules to detect fake crypto mining variants

### DIFF
--- a/indicators/fake-crypto-mining-MiningPool.yml
+++ b/indicators/fake-crypto-mining-MiningPool.yml
@@ -1,0 +1,30 @@
+title: Fake crypto mining - MiningPool
+
+description: |
+    Detects a malicious DApp that pretends to be a cloud mining platform.
+
+references:
+    - https://urlscan.io/result/8d6613c0-8489-4938-a243-dd7e3b8d3ffa/
+    - https://urlscan.io/result/d31045f8-94f8-4fa1-93a2-d0e632ae1680/
+    - https://urlscan.io/result/daeccc05-0a07-4903-b642-b3adc5b73d7c/
+    - https://urlscan.io/result/ed9b69a4-dc6c-4652-9451-d65d2df9517b/
+    - https://urlscan.io/result/268fe95d-d555-4d6d-af4f-96d7858bda50/
+
+detection:
+
+    identifier:
+      js|contains|all:
+        - 'topText1'
+        - 'topText2'
+        - 'TeamProfile'
+        - 'levelText1'
+        - 'checkText1'
+        - 'MiningPool'
+        - 'CurrentHashrate'
+        - 'Totalparticipation'
+        - 'miningOutputTip'
+
+    condition: identifier
+
+tags:
+  - cryptocurrency

--- a/indicators/fake-crypto-mining-ReceiveVoucher.yml
+++ b/indicators/fake-crypto-mining-ReceiveVoucher.yml
@@ -1,0 +1,29 @@
+title: Fake crypto mining - ReceiveVoucher
+
+description: |
+    Detects a malicious DApp that pretends to be a cloud mining platform
+    while presenting fake audit reports.
+
+references:
+    - https://urlscan.io/result/3b876cbb-9b3f-43e1-aaea-7fdbdfa9bf89/
+    - https://urlscan.io/result/47f06aec-35bb-495d-9cf8-df58178a68d1/
+    - https://urlscan.io/result/5be3b536-a4bd-4f81-b9be-1980ef3f955b/
+    - https://urlscan.io/result/d14625b5-d46a-44cb-afba-73072046626d/
+    - https://urlscan.io/result/714ba508-69aa-48de-b1e3-e53b51cbff38/
+    - https://urlscan.io/result/468f540d-4c14-4dca-ad8d-9ed9cca27e41/
+    - https://urlscan.io/result/6e2ae131-8b6a-4668-9b13-0df040d677dc/
+    - https://urlscan.io/result/7c66056f-fc6f-4e04-ac48-1160f8ac77c4/
+
+detection:
+
+    identifier:
+      html|contains|all:
+        - "Receive Voucher"
+        - "You need to pay a miner's fee"
+        - "audit report"
+        - "Wallet amount"
+
+    condition: identifier
+
+tags:
+  - cryptocurrency

--- a/indicators/fake-crypto-mining-arbitrageProducts.yml
+++ b/indicators/fake-crypto-mining-arbitrageProducts.yml
@@ -1,0 +1,24 @@
+title: Fake crypto mining - arbitrageProducts
+
+description: |
+    Detects a malicious DApp that pretends to be a cloud mining
+    operator and an AI arbitrage trading platform.
+
+references:
+    - https://urlscan.io/result/972d8029-c084-44c9-b156-b3a6a2a41181/
+    - https://urlscan.io/result/e5112130-88ed-4734-8346-8d4931335e93/
+    - https://urlscan.io/result/3394af82-a379-4596-ab5b-270c56272501/
+    - https://urlscan.io/result/2968d02e-95c2-4398-98e7-f00f22ab1768/
+
+detection:
+
+    identifier:
+      js|contains|all:
+        - 'arbitrageProducts'
+        - 'miningMachine'
+        - 'walletDeposit'
+
+    condition: identifier
+
+tags:
+  - cryptocurrency


### PR DESCRIPTION
# Three rules for fake crypto mining variants

Fake crypto mining - ReceiveVoucher (`fake-crypto-mining-arbitrageProducts.yml`)

Detects a malicious DApp that pretends to be a cloud mining platform while presenting fake audit reports.

References:
    - https://urlscan.io/result/3b876cbb-9b3f-43e1-aaea-7fdbdfa9bf89/
    - https://urlscan.io/result/47f06aec-35bb-495d-9cf8-df58178a68d1/
    - https://urlscan.io/result/5be3b536-a4bd-4f81-b9be-1980ef3f955b/
    - https://urlscan.io/result/d14625b5-d46a-44cb-afba-73072046626d/
    - https://urlscan.io/result/714ba508-69aa-48de-b1e3-e53b51cbff38/
    - https://urlscan.io/result/468f540d-4c14-4dca-ad8d-9ed9cca27e41/
    - https://urlscan.io/result/6e2ae131-8b6a-4668-9b13-0df040d677dc/
    - https://urlscan.io/result/7c66056f-fc6f-4e04-ac48-1160f8ac77c4/

----

Fake crypto mining - MiningPool (`fake-crypto-mining-MiningPool.yml`)

Detects a malicious DApp that pretends to be a cloud mining platform.

References:
    - https://urlscan.io/result/8d6613c0-8489-4938-a243-dd7e3b8d3ffa/
    - https://urlscan.io/result/d31045f8-94f8-4fa1-93a2-d0e632ae1680/
    - https://urlscan.io/result/daeccc05-0a07-4903-b642-b3adc5b73d7c/
    - https://urlscan.io/result/ed9b69a4-dc6c-4652-9451-d65d2df9517b/
    - https://urlscan.io/result/268fe95d-d555-4d6d-af4f-96d7858bda50/

----

Fake crypto mining - arbitrageProducts (`fake-crypto-mining-arbitrageProducts.yml`)

Detects a malicious DApp that pretends to be a cloud mining operator and an AI arbitrage trading platform.

References:
    - https://urlscan.io/result/972d8029-c084-44c9-b156-b3a6a2a41181/
    - https://urlscan.io/result/e5112130-88ed-4734-8346-8d4931335e93/
    - https://urlscan.io/result/3394af82-a379-4596-ab5b-270c56272501/
    - https://urlscan.io/result/2968d02e-95c2-4398-98e7-f00f22ab1768/