### PR TITLE
Create indicator: Daviplata Phishing Kit jwL1yd

### DIFF
--- a/indicators/daviplata-jwl1yd.yml
+++ b/indicators/daviplata-jwl1yd.yml
@@ -1,0 +1,32 @@
+title: Daviplata Phishing Kit jwL1yd
+description: |
+    Detects a phishing kit targeting Daviplata - a digital platform for making electronic transactions and payments using a mobile phone. Owned by Davivienda, a financial services company based in Colombia.
+    This was found as a result of this kit being deployed on Replit.
+
+
+references:
+    - https://www.daviplata.com/
+    - https://urlscan.io/result/e60e1ce6-ad53-4b9f-9798-1bd955685e2e/
+    - https://urlscan.io/result/ad4c7827-19e4-4ba9-91d2-29638b6cd212/
+    - https://urlscan.io/result/860f4e25-981c-4525-aa1c-9bb2cb5dda4a/
+    - https://urlscan.io/result/4411b6f0-8b69-4a87-817b-070896e095db/
+
+detection:
+
+    hashes:
+      html|contains|all:
+        - 2.d18bb301
+        - main.8d29879f
+
+    images:
+      html|contains|all:
+        - logdav.png
+        - bottom.png
+
+
+    condition: hashes and images
+
+tags:
+  - kit
+  - target.daviplata
+  - target_country.colombia


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Creator**

- **Test**
✅ Indicator matches **`4`**/**`4`** referenced Urlscan results.

- **Tags**: `kit`, `target.daviplata`, `target_country.colombia`
- **Name:**
`daviplata-jwl1yd` - `Daviplata Phishing Kit jwL1yd`
- **Description:**
```
Detects a phishing kit targeting Daviplata - a digital platform for making electronic transactions and payments using a mobile phone. Owned by Davivienda, a financial services company based in Colombia.
This was found as a result of this kit being deployed on Replit.
```
- **References:** (`5`)
https://www.daviplata.com/
https://urlscan.io/result/e60e1ce6-ad53-4b9f-9798-1bd955685e2e/
https://urlscan.io/result/ad4c7827-19e4-4ba9-91d2-29638b6cd212/
https://urlscan.io/result/860f4e25-981c-4525-aa1c-9bb2cb5dda4a/
https://urlscan.io/result/4411b6f0-8b69-4a87-817b-070896e095db/
- **Screenshot:**
<img src="https://urlscan.io/screenshots/e60e1ce6-ad53-4b9f-9798-1bd955685e2e.png" width="800" height="600" />