### PR TITLE
Enable passing in a slice of rules to evaluate

### DIFF
--- a/iok.go
+++ b/iok.go
@@ -30,15 +30,19 @@ type Input struct {
 }
 
 func GetMatches(input Input) ([]sigma.Rule, error) {
+	return GetMatchesForRules(input, evaluators)
+}
+
+func GetMatchesForRules(input Input, rules []*evaluator.RuleEvaluator) ([]sigma.Rule, error) {
 	matches := []sigma.Rule{}
-	for _, evaluator := range evaluators {
-		result, err := evaluator.Matches(context.Background(), convertInput(input))
+	for _, rule := range rules {
+		result, err := rule.Matches(context.Background(), convertInput(input))
 		if err != nil {
-			return nil, fmt.Errorf("error evaluating %s: %w", evaluator.Title, err)
+			return nil, fmt.Errorf("error evaluating %s: %w", rule.Title, err)
 		}
 
 		if result.Match {
-			matches = append(matches, evaluator.Rule)
+			matches = append(matches, rule.Rule)
 		}
 	}
 	return matches, nil


### PR DESCRIPTION
This allows the live-reloading of rules on phish.report/IOK to work properly.

Previously although the list of rules was live-reloaded when new commits were merged into this repository, the new rules didn't actually get evaluated.

With this change, the phish.report server can supply its own list of rules to use for evaluation, rather than always whatever ruleset is baked into the current version of the IOK library