### PR TITLE
Adds the 'cloning' tag to an indicator

### DIFF
--- a/indicators/bazhanwang-website-copier.yml
+++ b/indicators/bazhanwang-website-copier.yml
@@ -11,3 +11,6 @@ detection:
     html|contains: '<!-- This web page is copied by the "https://bazhan.wang" -->'
     
   condition: copierSignature
+
+tags:
+  - cloning


### PR DESCRIPTION
Rules that match website copiers/cloners must have the 'cloning' tag.