### PR TITLE
Create indicator: Generic Netflix Phishing Kit AhYsqq

### DIFF
--- a/indicators/generic-netflix-ahysqq.yml
+++ b/indicators/generic-netflix-ahysqq.yml
@@ -1,0 +1,32 @@
+title: Generic Netflix Phishing Kit AhYsqq
+description: |
+    Detects generic phishing kits targeting Netflix that copy common assets and leave breadcrumbs.
+
+
+references:
+    - https://urlscan.io/result/67259e10-b406-4df6-b18c-afffd0133a21/
+    - https://urlscan.io/result/283df94f-4a50-4d3a-b89d-0092c03c8bc3/
+    - https://urlscan.io/result/57cabf7f-35c4-455e-b4d0-96b5f2835b98/
+    - https://urlscan.io/result/fbb086c6-73bb-4b9b-b584-366c644220b4/
+    - https://urlscan.io/result/12125ecc-0b2b-4f17-82c7-3d01fab35d84/
+
+detection:
+
+    originTrialToken:
+      html|contains:
+        - <meta http-equiv="origin-trial" data-feature="EME Extension - Policy Check" data-expires="2018-11-26" content="Aob+++752GiUzm1RNSIkM9TINnQDxTlxz02v8hFJK/uGO2hmXnJqH8c/ZpI05b2nLsHDhGO3Ce2zXJUFQmO7jA4AAAB1eyJvcmlnaW4iOiJodHRwczovL25ldGZsaXguY29tOjQ0MyIsImZlYXR1cmUiOiJFbmNyeXB0ZWRNZWRpYUhkY3BQb2xpY3lDaGVjayIsImV4cGlyeSI6MTU0MzI0MzQyNCwiaXNTdWJkb21haW4iOnRydWV9">
+
+    assign:
+      html|contains:
+        - window.netflix = window.netflix
+
+    cdnDomain:
+      html|contains:
+        - assets.nflxext.com
+
+
+    condition: originTrialToken and assign and cdnDomain
+
+tags:
+  - kit
+  - target.netflix


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Builder**

- **Tests:**
✅ Indicator matches **`5`**/**`5`** referenced Urlscan results.

- **Tags**: `kit`, `target.netflix`
- **Name:**
`generic-netflix-ahysqq` - `Generic Netflix Phishing Kit AhYsqq`
- **Description:**
```
Detects generic phishing kits targeting Netflix that copy common assets and leave breadcrumbs.
```
- **References:** (`5`)
https://urlscan.io/result/67259e10-b406-4df6-b18c-afffd0133a21/
https://urlscan.io/result/283df94f-4a50-4d3a-b89d-0092c03c8bc3/
https://urlscan.io/result/57cabf7f-35c4-455e-b4d0-96b5f2835b98/
https://urlscan.io/result/fbb086c6-73bb-4b9b-b584-366c644220b4/
https://urlscan.io/result/12125ecc-0b2b-4f17-82c7-3d01fab35d84/
- **Screenshot:**
<img src="https://urlscan.io/screenshots/67259e10-b406-4df6-b18c-afffd0133a21.png" width="800" height="600" />