### PR TITLE
Create indicator: Outlook Phishing Kit hCO41m

### DIFF
--- a/indicators/outlook-hco41m.yml
+++ b/indicators/outlook-hco41m.yml
@@ -22,12 +22,12 @@ detection:
       html|contains:
         - <img src="k.png" class="img-fluid">
 
-    harvester:
+    logoGenerator:
       html|contains:
-        - https://esperanzahumura.org/d2/post.php
+        - logo.clearbit.com
 
 
-    condition: title and logo and privateComputerCheckmark and harvester
+    condition: title and logo and privateComputerCheckmark and logoGenerator
 
 tags:
   - kit

--- a/indicators/outlook-hco41m.yml
+++ b/indicators/outlook-hco41m.yml
@@ -1,0 +1,34 @@
+title: Outlook Phishing Kit hCO41m
+description: |
+    Detects a phishing kit pretending to be Outlook and attempting to capture the user's credentials.
+    Found as a result of this kit being deployed on Replit.
+
+
+references:
+    - https://urlscan.io/result/ef32cd01-2a2c-4513-bdc2-d44e7d3f870c/
+    - https://urlscan.io/result/686725c9-178d-494d-afbb-25900318cb70/
+
+detection:
+
+    title:
+      html|contains:
+        - <title>Document</title>
+
+    logo:
+      html|contains:
+        - <img src="logo.png" class="img-fluid">
+
+    privateComputerCheckmark:
+      html|contains:
+        - <img src="k.png" class="img-fluid">
+
+    harvester:
+      html|contains:
+        - https://esperanzahumura.org/d2/post.php
+
+
+    condition: title and logo and privateComputerCheckmark and harvester
+
+tags:
+  - kit
+  - target.outlook


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Builder**

- **Tests:**
✅ Indicator matches **`2`**/**`2`** referenced Urlscan results.

- **Tags**: `kit`, `target.outlook`
- **Name:**
`outlook-hco41m` - `Outlook Phishing Kit hCO41m`
- **Description:**
```
Detects a phishing kit pretending to be Outlook and attempting to capture the user's credentials.
Found as a result of this kit being deployed on Replit.
```
- **References:** (`2`)
https://urlscan.io/result/ef32cd01-2a2c-4513-bdc2-d44e7d3f870c/
https://urlscan.io/result/686725c9-178d-494d-afbb-25900318cb70/
- **Screenshot:**
<img src="https://urlscan.io/screenshots/ef32cd01-2a2c-4513-bdc2-d44e7d3f870c.png" width="800" height="600" />