### PR TITLE
Create indicator: Microsoft Phishing Kit Landing Page 4NCTpU

### DIFF
--- a/indicators/microsoft-landing-page-4nctpu.yml
+++ b/indicators/microsoft-landing-page-4nctpu.yml
@@ -16,11 +16,11 @@ detection:
 
     favicon:
       html|contains:
-        - link rel="icon" href="𝖋𝖆𝖛𝖎𝖈𝖔𝖓.png"
+        - 𝖋𝖆𝖛𝖎𝖈𝖔𝖓.png
 
     microsoftLogo:
       html|contains:
-        - img src="./cactusjack_files/𝟎𝖚𝖙𝟏𝟎𝟎𝖐.jpg"
+        - 𝟎𝖚𝖙𝟏𝟎𝟎𝖐.jpg
 
     continueButton:
       html|contains:

--- a/indicators/microsoft-landing-page-4nctpu.yml
+++ b/indicators/microsoft-landing-page-4nctpu.yml
@@ -1,0 +1,34 @@
+title: Microsoft Phishing Kit Landing Page 4NCTpU
+description: |
+    Detects the landing page of a Spanish-speaking phishing kit targeting Microsoft with two stages.
+    
+    The first stage is a landing page with a "Start the corresponding verification process" message, on the second stage the user is asked to enter their credentials. The stages switch using a redirect through an anchor.
+    
+    The detection of this tiny HTML page is based on the fact that the attacker thought it's a good idea to use special characters for their asset URLs.
+    
+    Found as a result of this kit being deployed on Replit.
+
+
+references:
+    - https://urlscan.io/result/329304f9-640c-4162-9d8d-d14e236a5deb/
+
+detection:
+
+    favicon:
+      html|contains:
+        - link rel="icon" href="𝖋𝖆𝖛𝖎𝖈𝖔𝖓.png"
+
+    microsoftLogo:
+      html|contains:
+        - img src="./cactusjack_files/𝟎𝖚𝖙𝟏𝟎𝟎𝖐.jpg"
+
+    continueButton:
+      html|contains:
+        - <a href="proceso-de-autenticacion-obligatoria.html" class="btn btn-success">Continuar</a>
+
+
+    condition: favicon and microsoftLogo and continueButton
+
+tags:
+  - kit
+  - target.microsoft


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Builder**

- **Tests:**
✅ Indicator matches **`1`**/**`1`** referenced Urlscan results.

- **Tags**: `kit`, `target.microsoft`
- **Name:**
`microsoft-landing-page-4nctpu` - `Microsoft Phishing Kit Landing Page 4NCTpU`
- **Description:**
```
Detects the landing page of a Spanish-speaking phishing kit targeting Microsoft with two stages.

The first stage is a landing page with a "Start the corresponding verification process" message, on the second stage the user is asked to enter their credentials. The stages switch using a redirect through an anchor.

The detection of this tiny HTML page is based on the fact that the attacker thought it's a good idea to use special characters for their asset URLs.

Found as a result of this kit being deployed on Replit.
```
- **References:** (`1`)
https://urlscan.io/result/329304f9-640c-4162-9d8d-d14e236a5deb/
- **Screenshot:**
<img src="https://urlscan.io/screenshots/329304f9-640c-4162-9d8d-d14e236a5deb.png" width="800" height="600" />