### PR TITLE
Create indicator: Outlook Phishing Kit kkPeRx

### DIFF
--- a/indicators/outlook-kkperx.yml
+++ b/indicators/outlook-kkperx.yml
@@ -1,0 +1,30 @@
+title: Outlook Phishing Kit kkPeRx
+description: |
+    Detects a phishing kit targeting Outlook. The page is designed to appear similar to the real Outlook Web App login page. Inline Base64 is used to locally load images.
+    Found as a result of this kit being deployed on Replit.
+
+
+references:
+    - https://urlscan.io/result/573face2-579c-4c40-8b36-7a00156bd492/
+
+detection:
+
+    title:
+      html|contains:
+        - <title>Outlook</title>
+
+    base64Logo:
+      html|contains|all:
+        - <img class="mouseHeader" src="data:image/png;base64
+        - alt="Outlook">
+
+    Base64Arrow:
+      html|contains:
+        - <img class="imgLnk" src="data:image/png;base64
+
+
+    condition: title and base64Logo and Base64Arrow
+
+tags:
+  - kit
+  - target.outlook


### PR DESCRIPTION
🎣 **Indicator of Kit PR through IOK Builder**

- **Tests:**
✅ Indicator matches **`1`**/**`1`** referenced Urlscan results.

- **Tags**: `kit`, `target.outlook`
- **Name:**
`outlook-kkperx` - `Outlook Phishing Kit kkPeRx`
- **Description:**
```
Detects a phishing kit targeting Outlook. The page is designed to appear similar to the real Outlook Web App login page. Inline Base64 is used to locally load images.
Found as a result of this kit being deployed on Replit.
```
- **References:** (`1`)
https://urlscan.io/result/573face2-579c-4c40-8b36-7a00156bd492/
- **Screenshot:**
<img src="https://urlscan.io/screenshots/573face2-579c-4c40-8b36-7a00156bd492.png" width="800" height="600" />