### PR TITLE
Add CI check to verify rule references

### DIFF
--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -1,0 +1,28 @@
+name: Rules
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  verify-rules:
+    name: Verify rule correctness
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.18
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v35
+        with:
+          files: indicators/*.{yml,yaml}
+
+      - name: Verify rule references
+        run: go run ./tools/internal/verify-rule-references ${{ steps.changed-files.outputs.all_changed_files }}

--- a/indicators/royal-mail-GbyBld.yml
+++ b/indicators/royal-mail-GbyBld.yml
@@ -13,5 +13,6 @@ detection:
   condition: css and html
 
 tags:
+  - kit
   - target.royal-mail
   - target_country.uk

--- a/indicators/royal-mail-GbyBld.yml
+++ b/indicators/royal-mail-GbyBld.yml
@@ -9,8 +9,8 @@ detection:
   css:
     requests|contains: css_GbyBld2YVfGaoHcw3eZJtGlhAxDTBpV3xkP06qLMwBI.css
   html:
-    html|contains: A total of <b>Â£2.99</b> is required to proceed the shipment towards your address.
-  condition: css and html
+    html|contains: "A total of <b>£2.99</b> is required to proceed the shipment towards your address."
+  condition: html
 
 tags:
   - kit

--- a/indicators/royal-mail-GbyBld.yml
+++ b/indicators/royal-mail-GbyBld.yml
@@ -1,0 +1,17 @@
+title: Royal Mail Phishing Kit GbyBld
+description: |
+  Detects a Royal Mail phishing kit claiming that "We've received a parcel for you with insufficient fees on the account"
+    
+references:
+  - https://urlscan.io/result/3069b2d5-95b6-4ac1-9fe4-8511e633db41
+
+detection:
+  css:
+    requests|contains: css_GbyBld2YVfGaoHcw3eZJtGlhAxDTBpV3xkP06qLMwBI.css
+  html:
+    html|contains: A total of <b>Â£2.99</b> is required to proceed the shipment towards your address.
+  condition: css and html
+
+tags:
+  - target.royal-mail
+  - target_country.uk

--- a/indicators/royal-mail-cd74ee99.yml
+++ b/indicators/royal-mail-cd74ee99.yml
@@ -1,0 +1,15 @@
+title: Royal Mail Phishing Kit cd74ee99
+description: |
+  Detects a Royal Mail phishing kit claiming that there are "issues with your shipping address"
+    
+references:
+  - https://urlscan.io/result/739b68d2-fd6b-460c-b9b3-7256b3c3cd07
+
+detection:
+  selection:
+    requests|contains: app.cd74ee99.css
+  condition: selection
+
+tags:
+  - target.royal-mail
+  - target_country.uk

--- a/indicators/royal-mail-cd74ee99.yml
+++ b/indicators/royal-mail-cd74ee99.yml
@@ -11,5 +11,6 @@ detection:
   condition: selection
 
 tags:
+  - kit
   - target.royal-mail
   - target_country.uk

--- a/indicators/royal-mail-dccfe2d7.yml
+++ b/indicators/royal-mail-dccfe2d7.yml
@@ -1,0 +1,15 @@
+title: Royal Mail Phishing Kit dccfe2d7
+description: |
+  Detects a Royal Mail phishing kit claiming that "a parcel cost £ 0.9 Payment failed"
+    
+references:
+  - https://urlscan.io/result/2e24e3be-de40-4eb4-bae3-7365c0076902
+
+detection:
+  selection:
+    requests|contains: app.dccfe2d7.css
+  condition: selection
+
+tags:
+  - target.royal-mail
+  - target_country.uk

--- a/indicators/royal-mail-dccfe2d7.yml
+++ b/indicators/royal-mail-dccfe2d7.yml
@@ -11,5 +11,6 @@ detection:
   condition: selection
 
 tags:
+  - kit
   - target.royal-mail
   - target_country.uk

--- a/tools/internal/verify-rule-references/verify-rule-references.go
+++ b/tools/internal/verify-rule-references/verify-rule-references.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/bradleyjkemp/sigma-go/evaluator"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	iok "phish.report/IOK"
+	"strings"
+	"syscall"
+	"time"
+)
+
+func main() {
+	rules := os.Args[1:]
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	ctx, cancel = signal.NotifyContext(ctx, syscall.SIGTERM)
+	defer cancel()
+
+	failed := false
+	for _, rule := range rules {
+		if err := verifyRule(ctx, rule); err != nil {
+			failed = true
+			log.Println("Rule", rule, "failed to verify ❌ ", err)
+		} else {
+			log.Println("Rule", rule, "verified ✅")
+		}
+	}
+	if failed {
+		os.Exit(1)
+	}
+}
+
+func verifyRule(ctx context.Context, ruleFile string) error {
+	ruleContents, err := os.ReadFile(ruleFile)
+	if err != nil {
+		return fmt.Errorf("failed to read rule %s: %w", ruleFile, err)
+	}
+
+	rule, err := iok.ParseRule(ruleFile, ruleContents)
+	if err != nil {
+		return fmt.Errorf("failed to parse rule %s: %w", ruleFile, err)
+	}
+
+	for _, reference := range rule.References {
+		if !strings.HasPrefix(reference, "https://urlscan.io/result/") {
+			continue
+		}
+
+		uuid := strings.TrimPrefix(reference, "https://urlscan.io/result/")
+
+		input, err := iok.InputFromURLScan(ctx, uuid, http.DefaultClient)
+		if err != nil {
+			return fmt.Errorf("failed to get IOK input %s: %w", uuid, err)
+		}
+
+		matches, err := iok.GetMatchesForRules(input, []*evaluator.RuleEvaluator{rule})
+		if err != nil {
+			return fmt.Errorf("failed to run IOK rule %s: %w", ruleFile, err)
+		}
+
+		if len(matches) == 0 {
+			return fmt.Errorf("expected %s to match %s reference, but it didn't", ruleFile, reference)
+		}
+	}
+	return nil // the rule matched all the urlscan.io results it references
+}


### PR DESCRIPTION
This adds a CI check which verifies that when a rule references a urlscan.io result in the `references` metadata, the rule actually matches that result

As a test, I've added three Royal Mail indicators