### PR TITLE
Add hostname field in rule input

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ IOK indicators are written using [Sigma](https://github.com/SigmaHQ/sigma)
 
 | Field name |   Type   | Description                                                                                          |
 |:----------:|:--------:|------------------------------------------------------------------------------------------------------|
+|  hostname  |  string  | The hostname of the site                                                                             |
 |    html    |  string  | The contents of the page HTML (as returned by the server)                                            |
 |     js     | []string | Contents of JavaScript from the page (includes inline scripts as well as scripts loaded externally)  |
 |    css     | []string | Contents of CSS from the page (includes inline stylesheets as well as externally loaded stylesheets) |

--- a/indicators/generic-netflix-ahysqq.yml
+++ b/indicators/generic-netflix-ahysqq.yml
@@ -23,5 +23,4 @@ detection:
   condition: originTrialToken and not (officialDomain or officialSubdomain)
 
 tags:
-  - kit
   - target.netflix

--- a/indicators/generic-netflix-ahysqq.yml
+++ b/indicators/generic-netflix-ahysqq.yml
@@ -1,31 +1,26 @@
 title: Generic Netflix Phishing Kit AhYsqq
 description: |
-    Detects generic phishing kits targeting Netflix that copy common assets and leave breadcrumbs.
-
+  Detects generic phishing kits targeting Netflix that copy common assets and leave breadcrumbs.
 
 references:
-    - https://urlscan.io/result/67259e10-b406-4df6-b18c-afffd0133a21/
-    - https://urlscan.io/result/283df94f-4a50-4d3a-b89d-0092c03c8bc3/
-    - https://urlscan.io/result/57cabf7f-35c4-455e-b4d0-96b5f2835b98/
-    - https://urlscan.io/result/fbb086c6-73bb-4b9b-b584-366c644220b4/
-    - https://urlscan.io/result/12125ecc-0b2b-4f17-82c7-3d01fab35d84/
+  - https://urlscan.io/result/67259e10-b406-4df6-b18c-afffd0133a21/
+  - https://urlscan.io/result/283df94f-4a50-4d3a-b89d-0092c03c8bc3/
+  - https://urlscan.io/result/57cabf7f-35c4-455e-b4d0-96b5f2835b98/
+  - https://urlscan.io/result/fbb086c6-73bb-4b9b-b584-366c644220b4/
+  - https://urlscan.io/result/12125ecc-0b2b-4f17-82c7-3d01fab35d84/
 
 detection:
+  originTrialToken:
+    html|contains:
+      - <meta http-equiv="origin-trial" data-feature="EME Extension - Policy Check" data-expires="2018-11-26" content="Aob+++752GiUzm1RNSIkM9TINnQDxTlxz02v8hFJK/uGO2hmXnJqH8c/ZpI05b2nLsHDhGO3Ce2zXJUFQmO7jA4AAAB1eyJvcmlnaW4iOiJodHRwczovL25ldGZsaXguY29tOjQ0MyIsImZlYXR1cmUiOiJFbmNyeXB0ZWRNZWRpYUhkY3BQb2xpY3lDaGVjayIsImV4cGlyeSI6MTU0MzI0MzQyNCwiaXNTdWJkb21haW4iOnRydWV9">
 
-    originTrialToken:
-      html|contains:
-        - <meta http-equiv="origin-trial" data-feature="EME Extension - Policy Check" data-expires="2018-11-26" content="Aob+++752GiUzm1RNSIkM9TINnQDxTlxz02v8hFJK/uGO2hmXnJqH8c/ZpI05b2nLsHDhGO3Ce2zXJUFQmO7jA4AAAB1eyJvcmlnaW4iOiJodHRwczovL25ldGZsaXguY29tOjQ0MyIsImZlYXR1cmUiOiJFbmNyeXB0ZWRNZWRpYUhkY3BQb2xpY3lDaGVjayIsImV4cGlyeSI6MTU0MzI0MzQyNCwiaXNTdWJkb21haW4iOnRydWV9">
+  officialDomain:
+    hostname: netflix.com
 
-    assign:
-      html|contains:
-        - window.netflix = window.netflix
+  officialSubdomain:
+    hostname|endswith: .netflix.com
 
-    cdnDomain:
-      html|contains:
-        - assets.nflxext.com
-
-
-    condition: originTrialToken and assign and cdnDomain
+  condition: originTrialToken and not (officialDomain or officialSubdomain)
 
 tags:
   - kit

--- a/iok.go
+++ b/iok.go
@@ -21,12 +21,13 @@ var config []byte
 var evaluators []*evaluator.RuleEvaluator
 
 type Input struct {
-	HTML     string
-	JS       []string
-	CSS      []string
-	Cookies  []string
-	Headers  []string
-	Requests []string
+	Hostname string   // Hostname is the hostname that the page was served from
+	HTML     string   // HTML contains the HTML contents of the primary page
+	JS       []string // JS contains all JavaScript on the page, whether an embedded script or loaded from a file
+	CSS      []string // CSS contains all CSS on the page, whether an embedded stylesheet or loaded from a file
+	Cookies  []string // Cookies contains all cookies set both by the initial page load and any subsequent requests
+	Headers  []string // Headers contains the headers of the initial page load
+	Requests []string // Requests contains a list of all URLs requested during the page load
 }
 
 func GetMatches(input Input) ([]sigma.Rule, error) {
@@ -35,8 +36,9 @@ func GetMatches(input Input) ([]sigma.Rule, error) {
 
 func GetMatchesForRules(input Input, rules []*evaluator.RuleEvaluator) ([]sigma.Rule, error) {
 	matches := []sigma.Rule{}
+	ruleInput := convertInput(input)
 	for _, rule := range rules {
-		result, err := rule.Matches(context.Background(), convertInput(input))
+		result, err := rule.Matches(context.Background(), ruleInput)
 		if err != nil {
 			return nil, fmt.Errorf("error evaluating %s: %w", rule.Title, err)
 		}
@@ -50,6 +52,7 @@ func GetMatchesForRules(input Input, rules []*evaluator.RuleEvaluator) ([]sigma.
 
 func convertInput(input Input) evaluator.Event {
 	return map[string]interface{}{
+		"hostname": input.Hostname,
 		"html":     input.HTML,
 		"js":       toInterfaceSlice(input.JS),
 		"css":      toInterfaceSlice(input.CSS),

--- a/urlscanio.go
+++ b/urlscanio.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 
 	"golang.org/x/net/html"
@@ -458,13 +459,18 @@ func InputFromURLScan(ctx context.Context, urlscanUUID string, client httpClient
 		return Input{}, fmt.Errorf("failed to decode search result: %w", err)
 	}
 
+	input := Input{}
+	u, err := url.Parse(result.Page.Url)
+	if err != nil {
+		return Input{}, fmt.Errorf("failed to parse result URL: %w", err)
+	}
+	input.Hostname = u.Hostname()
+
 	domReq, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://urlscan.io/dom/"+result.Task.Uuid, nil)
 	domResp, err := client.Do(domReq)
 	if err != nil {
 		return Input{}, fmt.Errorf("failed to get result html: %w", err)
 	}
-
-	input := Input{}
 
 	resultHTML, _ := io.ReadAll(domResp.Body)
 	input.HTML = string(resultHTML)


### PR DESCRIPTION
Adds a hostname field that can be matched on in rules. This fixes #181 where we want to be able to match on the origin trial token being present on any domain that isn't an official Netflix one

I'm also proposing that this can be used for a new type of rule for identifying targets of phishing sites by looking for direct quotes from official brand websites where the domain is not the official one (which is essentially what this Netflix rule is doing)