### PR TITLE
Add new DOM field and update HTML field definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ IOK indicators are written using [Sigma](https://github.com/SigmaHQ/sigma)
 |:----------:|:--------:|------------------------------------------------------------------------------------------------------|
 |  hostname  |  string  | The hostname of the site                                                                             |
 |    html    |  string  | The contents of the page HTML (as returned by the server)                                            |
+|    dom     |  string  | The contents of the page HTML after loading (e.g. after javascript has executed)                     |
 |     js     | []string | Contents of JavaScript from the page (includes inline scripts as well as scripts loaded externally)  |
 |    css     | []string | Contents of CSS from the page (includes inline stylesheets as well as externally loaded stylesheets) |
 |  cookies   | []string | Cookies from the page. Each is in the form `cookieName=value`                                        |

--- a/indicators/amazon-token-cryptocurrency-scam-shfxgk.yml
+++ b/indicators/amazon-token-cryptocurrency-scam-shfxgk.yml
@@ -10,19 +10,17 @@ references:
     - https://urlscan.io/result/b87affd1-1f6e-4bd8-b49e-d534993e96bb/
 
 detection:
-
     title:
       html|contains:
         - <title>Amazon Pre-Sale for AMZ (up to 200% bonus)</title>
 
     meta:
       html|contains:
-        - <meta name="description" content="Cryptocash is Professional Creative Template">
+        - <meta name="description" content="Cryptocash is Professional Creative Template" />
 
     css:
       requests|contains:
         - cryptocoins.css
-
 
     condition: title and meta and css
 

--- a/indicators/banco-davivienda-067fef0.yml
+++ b/indicators/banco-davivienda-067fef0.yml
@@ -15,10 +15,7 @@ detection:
   otherFakeLogo: 
     requests|contains: 'https://seeklogo.com/images/D/daviplata-logo-750F0FC1B7-seeklogo.com.png'
 
-  backlinkReference:
-    html|contains: '<a class="logo" href="https://loaosanjjdda.lusamarilla.repl.co/#" target="_blank">'
-
-  condition: fakeLogo and otherFakeLogo and backlinkReference
+  condition: fakeLogo and otherFakeLogo
 
 tags:
   - target.bancodavivienda

--- a/indicators/patelco-48ba653f.yml
+++ b/indicators/patelco-48ba653f.yml
@@ -13,7 +13,7 @@ detection:
     html|contains: '<link rel="stylesheet" type="text/css" href="VisitorIdentificationCSS.aspx.css">'
 
   formError:
-    html|contains: '<div class="form-error" id="B21AD518E4EF4F3DBCF943D0B6EDE8A3-error" tabindex="-1">Please enter a search term</div>'
+    html|contains: '<div class="form-error" id="B21AD518E4EF4F3DBCF943D0B6EDE8A3-error" tabindex="-1">Please'
 
   condition: stylesheet and formError
 

--- a/indicators/remitly-47bfa74f.yml
+++ b/indicators/remitly-47bfa74f.yml
@@ -1,0 +1,13 @@
+title: Remitly Phishing Kit 47bfa74f
+references:
+  - https://urlscan.io/result/47bfa74f-3efb-4dd1-b9ec-a9a862cf6a5b
+
+detection:
+  httrack:
+    html|contains: "<!-- Mirrored from www.remitly.com/us/en/users/login by HTTrack Website Copier/3.x [XR&CO'2014], Sat, 18 Mar 2023 02:53:11 GMT -->"
+
+  condition: httrack
+
+tags:
+  - kit
+  - target.remitly

--- a/indicators/rhadamanthys-stealer-26461dbb.yml
+++ b/indicators/rhadamanthys-stealer-26461dbb.yml
@@ -13,13 +13,13 @@ references:
 detection: 
     
   pageTitle:
-    html|contains: 'Dashboard - Rhadamanthys'
+    dom|contains: 'Dashboard - Rhadamanthys'
     
   logo:
-    html|contains: 'data-v-9beba3d6="" src="assets/logo.faa4fd30.svg"'
+    dom|contains: 'data-v-9beba3d6="" src="assets/logo.faa4fd30.svg"'
     
   copyrightFooter:
-    html|contains: 'Copyright © 2022 rhadamanthys'
+    dom|contains: 'Copyright © 2022 rhadamanthys'
    
   condition: logo and pageTitle
 

--- a/indicators/settingsjs-crypto-drainer-d810a56.yml
+++ b/indicators/settingsjs-crypto-drainer-d810a56.yml
@@ -4,7 +4,6 @@ description: |
     own configuration file called settings.js.
 
 references:
-    - https://urlscan.io/result/d810a56f-4ce0-4d0f-95ef-2fb338921fbb
     - https://urlscan.io/result/fec90b9f-cc8c-4d83-ac66-7b58010b7ad0
 
 detection:

--- a/indicators/smu-crypto-drainer-d9da4dc1.yml
+++ b/indicators/smu-crypto-drainer-d9da4dc1.yml
@@ -11,7 +11,7 @@ references:
 
 detection:
 
-    drainerFilers:
+    drainerFiles:
       requests|contains|all: 
         - 'utils.js'
         - 'showMess.js'

--- a/indicators/telekom-deutschland-34f36ea7.yml
+++ b/indicators/telekom-deutschland-34f36ea7.yml
@@ -13,13 +13,13 @@ references:
 detection:
 
     csrfTokenName:
-        js|contains: 'xsrf_rU86LhWL7rEI3N39kv0Evw'
+        html|contains: 'xsrf_rU86LhWL7rEI3N39kv0Evw'
 
     csrfTokenValue:
-        js|contains: 'ELotLohGqbr24MkEJvabkg'
+        html|contains: 'ELotLohGqbr24MkEJvabkg'
 
     transactionId:
-        js|contains: 'cc832e58-f790-49f8-b8bc-1f64b300c52b'
+        html|contains: 'cc832e58-f790-49f8-b8bc-1f64b300c52b'
 
     condition: csrfTokenName and csrfTokenValue and transactionId
 

--- a/indicators/twitter-91a19aa.yml
+++ b/indicators/twitter-91a19aa.yml
@@ -3,11 +3,7 @@ description: |
     Detects a phishing kit developed by a Turkish actor
     targeting users of Twitter.
 
-references:
-    - https://urlscan.io/result/084ea74d-50a6-4e58-bca2-e5b83cebb715
-
 detection:
-
     pageFavicon:
       html|contains: 'https://www.imajkoruma.com/wp-content/uploads/2019/02/twitter.png'
 

--- a/iok.go
+++ b/iok.go
@@ -22,7 +22,8 @@ var evaluators []*evaluator.RuleEvaluator
 
 type Input struct {
 	Hostname string   // Hostname is the hostname that the page was served from
-	HTML     string   // HTML contains the HTML contents of the primary page
+	DOM      string   // DOM contains the HTML contents of the primary page *after* it has loaded
+	HTML     string   // HTML contains the HTML response of the primary page
 	JS       []string // JS contains all JavaScript on the page, whether an embedded script or loaded from a file
 	CSS      []string // CSS contains all CSS on the page, whether an embedded stylesheet or loaded from a file
 	Cookies  []string // Cookies contains all cookies set both by the initial page load and any subsequent requests
@@ -53,6 +54,7 @@ func GetMatchesForRules(input Input, rules []*evaluator.RuleEvaluator) ([]sigma.
 func convertInput(input Input) evaluator.Event {
 	return map[string]interface{}{
 		"hostname": input.Hostname,
+		"dom":      input.DOM,
 		"html":     input.HTML,
 		"js":       toInterfaceSlice(input.JS),
 		"css":      toInterfaceSlice(input.CSS),

--- a/tools/internal/verify-rule-references/verify-rule-references.go
+++ b/tools/internal/verify-rule-references/verify-rule-references.go
@@ -16,7 +16,7 @@ import (
 
 func main() {
 	rules := os.Args[1:]
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 	ctx, cancel = signal.NotifyContext(ctx, syscall.SIGTERM)
 	defer cancel()


### PR DESCRIPTION
The field currently called "html" was actually subtly broken in that it contained the DOM contents from urlscan.io **not** the initial HTML response from the server.

This meant:
* Some rules couldn't be written because the detection strings were removed by the DOM parser
* Other rules were confusing to write because the HTML and DOM differed subtly in e.g. whitespace

To fix this, there's now a new field `dom` which contains this DOM contents and the `html` field actually contains what it's documented to contain.

In doing so, I had to fix up a couple of rules which were relying on the broken behaviour