### PR TITLE
Use CaseSensitive sigma-go setting to improve performance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/bradleyjkemp/cupaloy/v2 v2.6.0
-	github.com/bradleyjkemp/sigma-go v0.6.1
+	github.com/bradleyjkemp/sigma-go v0.6.4
 	golang.org/x/net v0.7.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/alecthomas/participle v0.7.1/go.mod h1:HfdmEuwvr12HXQN44HPWXR0lHmVolV
 github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0 h1:knToPYa2xtfg42U3I6punFEjaGFKWQRXJwj0JTv4mTs=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
-github.com/bradleyjkemp/sigma-go v0.6.1 h1:Pcorn3yOSACgcD8U7f8mss+ZIBgeVpi+09pB0jz3zHA=
-github.com/bradleyjkemp/sigma-go v0.6.1/go.mod h1:E0zOiUWS9/tvbSj6hsA9PXtplKygYTJ7hxgvWUcjJmE=
+github.com/bradleyjkemp/sigma-go v0.6.4 h1:J6Sqwbgv7wsEuP7xbsG8dvTrTc9lhkf5BvYF+gO9vzc=
+github.com/bradleyjkemp/sigma-go v0.6.4/go.mod h1:fHCN8y8cC1l5CYY7oOhPIznHmj/yeGxUvU+vAV7alr4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/iok.go
+++ b/iok.go
@@ -90,7 +90,7 @@ func ParseRule(path string, contents []byte) (*evaluator.RuleEvaluator, error) {
 		rule.ID, _, _ = strings.Cut(filepath.Base(path), ".")
 	}
 
-	return evaluator.ForRule(rule, evaluator.WithConfig(config)), nil
+	return evaluator.ForRule(rule, evaluator.WithConfig(config), evaluator.CaseSensitive), nil
 }
 
 func init() {


### PR DESCRIPTION
IOK inputs are very large (often many megabytes) because they contain the full HTML/JS/CSS of a webpage. This causes performance issues when doing case insensitive matches so this changes the behaviour to make matching case sensitive