### PR TITLE
Create indicator: Rakuten Phishing Kit 1f160470

### DIFF
--- a/indicators/rakuten-1f160470.yml
+++ b/indicators/rakuten-1f160470.yml
@@ -1,26 +1,24 @@
 title: Rakuten Phishing Kit 1f160470
 description: |
     Detects a Rakuten phishing kit targeting Japanese users.
-
 references:
   - https://urlscan.io/result/1f160470-9cc5-4ba3-b5a1-1f24a9bc113c
   - https://urlscan.io/result/236af6c7-cc5f-49ee-b72e-5dc01f023899
 
 detection:
 
-    RakutenTitle:
-        title:
-            - "【楽天】ログイン"
+    countScriptRef:
+      dom|contains: '<script language="JavaScript" src="count.php"></script>'
 
-    ChallengerJS: 
-        requests|contains: 'challenger.js'
+    hiddenInput:
+      dom|contains: '<input type="hidden" name="rat" id="ratAccountId" value="429">'
 
-    ScriptCharacteristic: 
-        js|contains|all: 
-            - 'typeof mkfp != "undefined"'
-            - '"undefined" != typeof FloatingChatButton'
+    assets:
+      requests|endswith|all:
+        - '/static/css/ichiba_chat_appender_v1_0.css'
+        - '/count.php'
 
-    condition: RakutenTitle and ChallengerJS and ScriptCharacteristic
+    condition: countScriptRef and hiddenInput and assets
 
 tags:
   - kit

--- a/indicators/rakuten-1f160470.yml
+++ b/indicators/rakuten-1f160470.yml
@@ -1,0 +1,29 @@
+title: Rakuten Phishing Kit 1f160470
+description: |
+    Detects a Rakuten phishing kit targeting Japanese users.
+
+references:
+  - https://urlscan.io/result/1f160470-9cc5-4ba3-b5a1-1f24a9bc113c
+  - https://urlscan.io/result/236af6c7-cc5f-49ee-b72e-5dc01f023899
+
+detection:
+
+    RakutenTitle:
+        title:
+            - "【楽天】ログイン"
+
+    ChallengerJS: 
+        html|contains: 
+            - 'type="text/javascript" src="static/js/challenger.js"'
+
+    scriptVariables: 
+        js|contains|all: 
+            - 'typeof mkfp != "undefined"'
+            - '"undefined" != typeof FloatingChatButton'
+
+    condition: RakutenTitle and ChallengerJS and scriptVariables
+
+tags:
+  - kit
+  - target.rakuten
+  - target_country.japan

--- a/indicators/rakuten-1f160470.yml
+++ b/indicators/rakuten-1f160470.yml
@@ -13,8 +13,7 @@ detection:
             - "【楽天】ログイン"
 
     ChallengerJS: 
-        html|contains: 
-            - 'type="text/javascript" src="static/js/challenger.js"'
+        requests|contains: 'challenger.js'
 
     ScriptCharacteristic: 
         js|contains|all: 

--- a/indicators/rakuten-1f160470.yml
+++ b/indicators/rakuten-1f160470.yml
@@ -16,12 +16,12 @@ detection:
         html|contains: 
             - 'type="text/javascript" src="static/js/challenger.js"'
 
-    scriptVariables: 
+    ScriptCharacteristic: 
         js|contains|all: 
             - 'typeof mkfp != "undefined"'
             - '"undefined" != typeof FloatingChatButton'
 
-    condition: RakutenTitle and ChallengerJS and scriptVariables
+    condition: RakutenTitle and ChallengerJS and ScriptCharacteristic
 
 tags:
   - kit


### PR DESCRIPTION
**Creating IOK for Rakuten Phishing targeting Japanese users.**

Description:
Detects a Rakuten phishing kit targeting Japanese users.

References:
https://urlscan.io/result/1f160470-9cc5-4ba3-b5a1-1f24a9bc113c
https://urlscan.io/result/236af6c7-cc5f-49ee-b72e-5dc01f023899

Tags:
`target.rakuten`,`target_country.japan`

Screenshot:
![rakuten](https://github.com/phish-report/IOK/assets/36557605/f621cd14-0ed5-4ed5-9004-0f12d420d92c)
