### PR TITLE
McAfee-Virus Phishing Kit 8wer3hwa

### DIFF
--- a/indicators/McAfee-Virus-8wer3hwa.yml
+++ b/indicators/McAfee-Virus-8wer3hwa.yml
@@ -1,0 +1,33 @@
+title: McAfee Virus Phishing Kit 8wer3hwa
+description: Detects phishing pages mimicking McAfee with suspicious behavior.
+level: likely_malicous
+    
+references:
+    # No References 
+
+detection:
+
+  mcafeeKeywords:
+    html|contains: "mcafee"
+    html|contains: "mcafee support"
+    html|contains: "mcafee security"
+  
+  urgencyIndicators:
+    html|contains: "immediate action"
+    html|contains: "account locked"
+    html|contains: "virus detected"
+
+  dataExfiltration:
+    html|element: input|attr: type|in: ["password", "credit-card", "social-security-number"]  
+    
+  suspiciousDomains:
+    hostname:
+      - mcafee.com
+
+  condition: mcafeeKeywords and not suspiciousDomains and (urgencyIndicators or dataExfiltration) 
+
+tags:
+  - kit
+  - target.mcafee
+  - target.phishing
+  

--- a/indicators/McAfee-Virus-8wer3hwa.yml
+++ b/indicators/McAfee-Virus-8wer3hwa.yml
@@ -20,11 +20,11 @@ detection:
   dataExfiltration:
     html|element: input|attr: type|in: ["password", "credit-card", "social-security-number"]  
     
-  suspiciousDomains:
+  realDomains:
     hostname:
       - mcafee.com
 
-  condition: mcafeeKeywords and not suspiciousDomains and (urgencyIndicators or dataExfiltration) 
+  condition: mcafeeKeywords and not realDomains and (urgencyIndicators or dataExfiltration) 
 
 tags:
   - kit


### PR DESCRIPTION
Detects phishing pages mimicking McAfee with suspicious behavior.
title: McAfee Virus Phishing Kit 8wer3hwa
description: Detects phishing pages mimicking McAfee with suspicious behavior.
level: likely_malicous
    
references:
    # No References 

detection:

  mcafeeKeywords:
    html|contains: "mcafee"
    html|contains: "mcafee support"
    html|contains: "mcafee security"
  
  urgencyIndicators:
    html|contains: "immediate action"
    html|contains: "account locked"
    html|contains: "virus detected"

  dataExfiltration:
    html|element: input|attr: type|in: ["password", "credit-card", "social-security-number"]  
    
  realDomains:
    hostname:
      - mcafee.com

  condition: mcafeeKeywords and not realDomains and (urgencyIndicators or dataExfiltration) 

tags:
  - kit
  - target.mcafee
  - target.phishing
  