### PR TITLE
Create pagopa-197bb96bc.yml

### DIFF
--- a/indicators/pagopa-197bb96bc.yml
+++ b/indicators/pagopa-197bb96bc.yml
@@ -20,3 +20,8 @@ detection:
       - pagopa.gov.it
 
   condition: requestsContent and not realDomain
+
+tags:
+  - kit
+  - target_country.italy
+  - target.pagopa

--- a/indicators/pagopa-197bb96bc.yml
+++ b/indicators/pagopa-197bb96bc.yml
@@ -1,7 +1,6 @@
-title: pagopa-payment-process-phishing
+title: PagoPA Phishing Kit 197bb96bc
 description: |
-  Sites sites that mimic the payment process of the PagoPA platform established by the Italian Government for payments to public administrations
-level: potentially_malicious
+  Detects sites that mimic the payment process of the PagoPA platform established by the Italian Government for payments to public administrations
 first_seen: 2025-03-27
 references:
     - https://cert-agid.gov.it/wp-content/uploads/2025/03/phishing_pagoPA.json

--- a/indicators/pagopa-payment-process-phishing.yaml
+++ b/indicators/pagopa-payment-process-phishing.yaml
@@ -1,0 +1,23 @@
+title: pagopa-payment-process-phishing
+description: |
+  Sites sites that mimic the payment process of the PagoPA platform established by the Italian Government for payments to public administrations
+level: potentially_malicious
+first_seen: 2025-03-27
+references:
+    - https://cert-agid.gov.it/wp-content/uploads/2025/03/phishing_pagoPA.json
+
+detection:
+  requestsContent:
+    requests|contains:
+      - 'choose.php'
+      - 'loader.php'
+      - 'keyb.png'
+      - 'fin.php'
+      - 'informations.php'
+      - 'recap.php'
+  realDomain:
+    hostname:
+      - pagopa.it
+      - pagopa.gov.it
+
+  condition: requestsContent and not realDomain


### PR DESCRIPTION
This rule is based on a phishing kit used in a campaign targeting Italian citizens, impersonating the "PagoPA" payment platform.

Full Indicators of Compromise of the campaign published by the Agenzia per l'Italia Digitale (AgID): https://cert-agid.gov.it/wp-content/uploads/2025/03/phishing_pagoPA.json