### PR TITLE
🚀 Create IOK: fortnite-locker-checker-phishing-kit-4e7c91a2

### DIFF
--- a/indicators/fortnite-locker-checker-phishing-kit-4e7c91a2.yml
+++ b/indicators/fortnite-locker-checker-phishing-kit-4e7c91a2.yml
@@ -1,0 +1,49 @@
+title: Fortnite Locker Checker Phishing Kit 4e7c91a2
+description: |
+    Detects an Epic Games / Fortnite phishing kit conducting an OAuth
+    authorization-code grab attack that bypasses 2FA. The kit directs victims
+    to authenticate on the legitimate epicgames.com OAuth endpoint, then
+    instructs them to paste the resulting authorization code back into the
+    phishing page where the kit exchanges it for a valid access_token via
+    Epic's API. The user's password never leaves Epic and 2FA is genuinely
+    passed, but the attacker captures a fully-authenticated session.
+
+    Identified by its proprietary `/.merc/captcha` anti-bot framework, the
+    `anubis_token` cookie (operator-rebranded fork of TecharoHQ/anubis), the
+    `/lupidrupigang/locker/` paths, and shared third-party asset hosting on
+    postimg.cc with Russian-transliteration filenames (`vhodebat` = login,
+    `shekeli` = money). Active across 65+ domains as of April 2026 spanning
+    V1, V2, V2 sub-variant, and V3 kit variants.
+references:
+    - https://urlscan.io/result/019dcad8-85fb-75e8-9a05-bb1e8c0b9110/
+    - https://urlscan.io/result/019dcad9-3b19-7052-a735-e93678117d7c/
+    - https://urlscan.io/result/019dcad9-af6b-7475-b75a-0df543b29fab/
+    - https://urlscan.io/result/019dcadc-ee18-724a-bc90-3e8c38ed79aa/
+    - https://urlscan.io/result/019dcadd-f5b5-70bb-8934-7dda9efc5e9d/
+detection:
+    mercCaptchaPath:
+        requests|contains: '/.merc/captcha'
+    anubisCookie:
+        cookies|contains: 'anubis_token='
+    challengeText:
+        html|contains: 'Click the shapes in order shown below'
+    oauthGrabFlow:
+        html|contains|all:
+            - 'Click on the Get Code button below to generate an authorization code'
+            - 'paste your authorization code to validate'
+    epicOAuthRedirect:
+        html|contains: 'epicgames.com/id/api/redirect?clientId=fortnitePCGameClient'
+    sharedAssets:
+        requests|contains:
+            - 'i.postimg.cc/DzGdT9Hg/vhodebat.png'
+            - 'i.postimg.cc/Z5B6PkbY/shekeli.png'
+            - 'i.postimg.cc/zBVNvkwF/locker1ver.png'
+            - 'raw.githubusercontent.com/sios-v/wolk/master/fonts/'
+    lupidrupigangPath:
+        requests|contains: '/lupidrupigang/locker/'
+    condition: mercCaptchaPath or (challengeText and anubisCookie) or (oauthGrabFlow and epicOAuthRedirect) or sharedAssets or lupidrupigangPath
+tags:
+    - kit
+    - target.epic-games
+    - target.fortnite
+    - oauth


### PR DESCRIPTION
🟢Additions:

- Add `fortnite-locker-checker-phishing-kit-4e7c91a2`

---

Detects an active Epic Games / Fortnite phishing kit conducting an OAuth authorization-code grab attack that bypasses 2FA.

**Campaign scale:** 65+ confirmed active domains as of April 2026 across four kit variants (V1, V2, V2 sub-variant, V3). Operator has a documented resurrection pattern (3 previously-killed domains brought back). Pre-staging behavior identified via 9-domain V2 sub-variant cluster running same kit framework with placeholder body copy.

**Detection composite:**
- Proprietary `/.merc/captcha` anti-bot framework path (kit-specific, never seen elsewhere)
- Operator-rebranded `anubis_token` cookie (forked from `TecharoHQ/anubis` which uses `techaro.lol-anubis-auth`)
- Kit-specific `/lupidrupigang/locker/` paths
- OAuth code-grab flow text (`"Click on the Get Code button..."` + `"paste your authorization code to validate"`) combined with Epic OAuth redirect URL
- Shared third-party asset hosting (postimg.cc with Russian-transliteration filenames `vhodebat`/`shekeli`; GitHub raw font hosting at `raw.githubusercontent.com/sios-v/wolk/master/fonts/`)

**False-positive risk:** Low. Each component indicator is unique to this operator's kit with no legitimate-use overlap.

**urlscan references** cover one domain per kit variant:
- V1 kit: `lootcap.info`
- V2 standard: `fortvalue.com`, `fortmev.com`
- V2 sub-variant: `fortwx.com`, `fortvx.com`

**Independent corroboration:** VirusTotal hash `be798ec7b9698b9e4ac1a57d45fca9cffd63b12e1ff24b11a9672ac9856d1e4c` (AlphaMountain.ai: Phishing; SOCRadar: Malware), urlscan auto-classifier flagging "Targeting brands: Epic Games (Gaming)", PCRisk article #35157.

**Parallel takedown reports filed:** Cloudflare (1 domain actioned, 62 follow-up), postimg.cc, GitHub (asset repo + promotion org), Epic Games Trust & Safety, HackerOne — this rule is the durable detection layer that survives ongoing domain rotation.